### PR TITLE
Bump @neo4j-cypher/react-codemirror to pre 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/styles": "^4.11.4",
     "@mui/material": "^5.3.0",
     "@mui/x-data-grid": "5.10.0",
-    "@neo4j-cypher/react-codemirror": "1.0.0-next.18",
+    "@neo4j-cypher/react-codemirror": "^1.0.0-next.18",
     "@nivo/bar": "^0.80.0",
     "@nivo/circle-packing": "^0.80.0",
     "@nivo/core": "^0.80.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/styles": "^4.11.4",
     "@mui/material": "^5.3.0",
     "@mui/x-data-grid": "5.10.0",
-    "@neo4j-cypher/react-codemirror": "^1.0.0-next.16",
+    "@neo4j-cypher/react-codemirror": "1.0.0-next.18",
     "@nivo/bar": "^0.80.0",
     "@nivo/circle-packing": "^0.80.0",
     "@nivo/core": "^0.80.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/styles": "^4.11.4",
     "@mui/material": "^5.3.0",
     "@mui/x-data-grid": "5.10.0",
-    "@neo4j-cypher/react-codemirror": "^1.0.0-next.18",
+    "@neo4j-cypher/react-codemirror": "^1.0.0-next.19",
     "@nivo/bar": "^0.80.0",
     "@nivo/circle-packing": "^0.80.0",
     "@nivo/core": "^0.80.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
     "@babel/runtime" "^7.20.6"
     "@neo4j-cypher/antlr4-browser" "1.0.0-next.0"
 
-"@neo4j-cypher/codemirror@1.0.0-next.17":
-  version "1.0.0-next.17"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.17.tgz#0b7ec9a5db11835bb3987de470055ed5c7d67481"
-  integrity sha512-y049mtg/LVMa3ZcCN2sWDfrZJC3UEvPuFgKY9u+EFQeJ9sG/hOb1w2yX4h27mphpyNDq5Z31NVTKpHdWSbJRzQ==
+"@neo4j-cypher/codemirror@1.0.0-next.18":
+  version "1.0.0-next.18"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.18.tgz#416674ff6ca3f868018c99acca62186e97a23c9d"
+  integrity sha512-fxAUVYPmEsY1grVOo8Rzb7OHbECGMPeWOhp4epLM1x1pS1fxeDlU/3L0vMOZe1USaUEImjvum4uFAS6hPt7bvw==
   dependencies:
     "@babel/runtime" "^7.20.6"
     "@codemirror/autocomplete" "^6.3.4"
@@ -1900,13 +1900,13 @@
     lodash.find "^4.6.0"
     lodash.includes "^4.3.0"
 
-"@neo4j-cypher/react-codemirror@^1.0.0-next.18":
-  version "1.0.0-next.18"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.18.tgz#7d89ebc8c3a51729c48950fba34a3f6226f1f861"
-  integrity sha512-KHmyqIoB9DoDKRL26bo0W+WbS4Lk/0LNFQDwDzTPyFn6ltdLZ+NJMBqEPxwCbOsSlE+BJLijiwBquXik8Ad+SQ==
+"@neo4j-cypher/react-codemirror@^1.0.0-next.19":
+  version "1.0.0-next.19"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.19.tgz#fb9755208618d88c3e4034eaac61dcfa84b55ba5"
+  integrity sha512-ABg82FC7ZZpibPAIgI40oCha1ZSn2AgY+jYR2/eC0PxivnKiH5AjdHimGnYEvPWyuRyBlXnbQ6AnvIe/80PG/A==
   dependencies:
     "@babel/runtime" "^7.20.6"
-    "@neo4j-cypher/codemirror" "1.0.0-next.17"
+    "@neo4j-cypher/codemirror" "1.0.0-next.18"
     codemirror "^6.0.1"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,7 +1900,7 @@
     lodash.find "^4.6.0"
     lodash.includes "^4.3.0"
 
-"@neo4j-cypher/react-codemirror@1.0.0-next.18":
+"@neo4j-cypher/react-codemirror@^1.0.0-next.18":
   version "1.0.0-next.18"
   resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.18.tgz#7d89ebc8c3a51729c48950fba34a3f6226f1f861"
   integrity sha512-KHmyqIoB9DoDKRL26bo0W+WbS4Lk/0LNFQDwDzTPyFn6ltdLZ+NJMBqEPxwCbOsSlE+BJLijiwBquXik8Ad+SQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
     "@babel/runtime" "^7.20.6"
     "@neo4j-cypher/antlr4-browser" "1.0.0-next.0"
 
-"@neo4j-cypher/codemirror@1.0.0-next.15":
-  version "1.0.0-next.15"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.15.tgz#03c8c1570d5b02042e281811c5c07b3fc3b89bc8"
-  integrity sha512-1YnZRwkPSImQ5rfOlStG6YrE6n4iGbvIS0NCM+g1+HsvqptuddZkhJ10ez+fDcDdfkLGbjhKDhKN/NxCC0gIUw==
+"@neo4j-cypher/codemirror@1.0.0-next.17":
+  version "1.0.0-next.17"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.17.tgz#0b7ec9a5db11835bb3987de470055ed5c7d67481"
+  integrity sha512-y049mtg/LVMa3ZcCN2sWDfrZJC3UEvPuFgKY9u+EFQeJ9sG/hOb1w2yX4h27mphpyNDq5Z31NVTKpHdWSbJRzQ==
   dependencies:
     "@babel/runtime" "^7.20.6"
     "@codemirror/autocomplete" "^6.3.4"
@@ -1900,13 +1900,13 @@
     lodash.find "^4.6.0"
     lodash.includes "^4.3.0"
 
-"@neo4j-cypher/react-codemirror@^1.0.0-next.16":
-  version "1.0.0-next.16"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.16.tgz#daf199d02d3dc526e885635109fdfb7ad95857c3"
-  integrity sha512-gSH/VIvkT/PuzmH4XadAVbVE+ctdkFwNW6dSCCJSUT4u8bO6tK26rnVLX9dcYbRLvGhs0feYkP88K3VhXKS4jQ==
+"@neo4j-cypher/react-codemirror@1.0.0-next.18":
+  version "1.0.0-next.18"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.18.tgz#7d89ebc8c3a51729c48950fba34a3f6226f1f861"
+  integrity sha512-KHmyqIoB9DoDKRL26bo0W+WbS4Lk/0LNFQDwDzTPyFn6ltdLZ+NJMBqEPxwCbOsSlE+BJLijiwBquXik8Ad+SQ==
   dependencies:
     "@babel/runtime" "^7.20.6"
-    "@neo4j-cypher/codemirror" "1.0.0-next.15"
+    "@neo4j-cypher/codemirror" "1.0.0-next.17"
     codemirror "^6.0.1"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":


### PR DESCRIPTION
Fixes a bug in the syntax highlighting where the decorations weren't being cleared, which apparently can cause a crash when the text value changes rapidly