### PR TITLE
Added release notes for 2.2.3

### DIFF
--- a/.github/workflows/master-deployment.yml
+++ b/.github/workflows/master-deployment.yml
@@ -79,7 +79,7 @@ jobs:
       context: .
       file: ./Dockerfile
       push: true
-      tags: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:2.2.2
+      tags: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:2.2.3
  build-docker-legacy:
    needs: build-test
    runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
       context: .
       file: ./Dockerfile
       push: true
-      tags: ${{ secrets.DOCKER_HUB_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_USERNAME }}/neodash:2.2.2
+      tags: ${{ secrets.DOCKER_HUB_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_USERNAME }}/neodash:2.2.3
 #  build-npm:
 #    needs: build-test
 #    runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN chown -R nginx:nginx /usr/share/nginx/html/
 USER nginx
 EXPOSE 5005
 HEALTHCHECK cmd curl --fail http://localhost:5005 || exit 1
-LABEL version="2.2.2"
+LABEL version="2.2.3"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
+## NeoDash 2.2.3
+This releases fixes a small set of bugs that slipped through the 2.2.3 release, and adds some minor features:
+- Added support for scatter plots by overriding a parameter in the line chart.
+- Added the ability to use dashboard parameter as filters in custom parameter selector queries.
+- Fixed breaking bug in parameter selector settings causing a white-screen error.
+- Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
+
 ## NeoDash 2.2.2
-The NeoDash 2.2.2 release is packed with a bunch of new usuability features:
+The NeoDash 2.2.2 release is packed with a bunch of new usability features:
 - Changed the built-in Cypher editor to a brand-new [CodeMirror Editor](https://github.com/neo4j-contrib/cypher-editor).
 - Rebuilt the **Parameter Select** component from scratch for improved stability, performance and extendability:
   - Added an optional setting to the parameter selector to display a different property from the one that is set by the selector.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,9 @@ This releases fixes a small set of bugs that slipped through the 2.2.3 release, 
 - Added the ability to use dashboard parameter as filters in custom parameter selector queries.
 - Fixed breaking bug in parameter selector settings causing a white-screen error.
 - Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
+- Added a quick fix for automatically resetting the parameter display value when the property display override is toggled.
 - Upversioned outdated dashboards and in the NeoDash Gallery.
+
   
 ## NeoDash 2.2.2
 The NeoDash 2.2.2 release is packed with a bunch of new usability features:

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@ This releases fixes a small set of bugs that slipped through the 2.2.3 release, 
 - Added the ability to use dashboard parameter as filters in custom parameter selector queries.
 - Fixed breaking bug in parameter selector settings causing a white-screen error.
 - Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
-
+- Upversioned outdated dashboards and in the NeoDash Gallery.
+  
 ## NeoDash 2.2.2
 The NeoDash 2.2.2 release is packed with a bunch of new usability features:
 - Changed the built-in Cypher editor to a brand-new [CodeMirror Editor](https://github.com/neo4j-contrib/cypher-editor).

--- a/docs/modules/ROOT/pages/developer-guide/deploy-a-build.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/deploy-a-build.adoc
@@ -34,7 +34,7 @@ Depending on the webserver type and version, this could be different directory.
 As an example - to copy the files to an nginx webserver using `scp`:
 
 ```bash
-scp neodash-2.2.2 username@host:/usr/share/nginx/html
+scp neodash-2.2.3 username@host:/usr/share/nginx/html
 ```
 
 NeoDash should now be visible by visiting your (sub)domain in the browser.

--- a/docs/modules/ROOT/pages/user-guide/reports/map.adoc
+++ b/docs/modules/ROOT/pages/user-guide/reports/map.adoc
@@ -109,7 +109,7 @@ relationship property to map to the arrow width. This lets you define
 widths on a relationship-specific level, if you have a property that
 directly maps to the width value.
 
-|Map Provider URL|Text|https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png| When specified, overrides Open Street map provider with a custom map tiles provider.
+|Map Provider URL|Text|https://\{s}.tile.openstreetmap.org/\{z}/\{x}/\{y}.png| When specified, overrides Open Street map provider with a custom map tiles provider.
 
 |Intensity Property (for heatmap)|Text|intensity|Optionally, and only for heatmaps, the node property to use as the intensity of that point on the heatmap. If left empty, all points will have the same intensity of 1. If one of the nodes in the results doesn't have the specific property, its intensity will be set to 0.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neodash",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "NeoDash - Neo4j Dashboard Builder",
   "neo4jDesktop": {
     "apiVersion": "^1.2.0"

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,3 +4,4 @@ This releases fixes a small set of bugs that slipped through the 2.2.3 release, 
 - Added the ability to use dashboard parameter as filters in custom parameter selector queries.
 - Fixed breaking bug in parameter selector settings causing a white-screen error.
 - Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
+- Upversioned outdated dashboards and in the NeoDash Gallery.

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,4 +4,5 @@ This releases fixes a small set of bugs that slipped through the 2.2.3 release, 
 - Added the ability to use dashboard parameter as filters in custom parameter selector queries.
 - Fixed breaking bug in parameter selector settings causing a white-screen error.
 - Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
+- Added a quick fix for automatically resetting the parameter display value when the property display override is toggled.
 - Upversioned outdated dashboards and in the NeoDash Gallery.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,15 +1,6 @@
-## NeoDash 2.2.2
-The NeoDash 2.2.2 release is packed with a bunch of new usuability features:
-- Changed the built-in Cypher editor to a brand-new [CodeMirror Editor](https://github.com/neo4j-contrib/cypher-editor).
-- Rebuilt the **Parameter Select** component from scratch for improved stability, performance and extendability:
-  - Added an optional setting to the parameter selector to display a different property from the one that is set by the selector.
-  - Use this to - for example - let users choose a name and set an ID for use by other reports.
-  - Fields no longer reset randomly when parameters are changed.
-  - Freetext fields are no longer slow - perform as fast as the other selectors.
-- Add the option to use rule-based styling based on dashboard parameters.
-- Changed rule-based styling on bar and pie charts to override color scheme instead of clear the scheme.
-- Extended the [Example Gallery](https://neodash-gallery.graphapp.io/) with several new demos.
-- Adding intermediate report error boundaries for improved app stability. 
-- Changed docker image name to `neo4jlabs/neodash`.
-- Improved documementation for developers.
-- Fixed inconsistent styling between different pop-up screens, and fixed report title placeholders.
+## NeoDash 2.2.3
+This releases fixes a small set of bugs that slipped through the 2.2.3 release, and adds some minor features:
+- Added support for scatter plots by overriding a parameter in the line chart.
+- Added the ability to use dashboard parameter as filters in custom parameter selector queries.
+- Fixed breaking bug in parameter selector settings causing a white-screen error.
+- Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).

--- a/src/card/settings/custom/CardSettingsContentPropertySelect.tsx
+++ b/src/card/settings/custom/CardSettingsContentPropertySelect.tsx
@@ -55,6 +55,7 @@ const NeoCardSettingsContentPropertySelect = ({
   if (settings.type == undefined) {
     onReportSettingUpdate('type', 'Node Property');
   }
+
   if (!parameterName && settings.entityType && settings.propertyType) {
     const entityAndPropertyType = `neodash_${settings.entityType}_${settings.propertyType}`;
     const formattedParameterId = formatParameterId(settings.id);
@@ -187,6 +188,13 @@ const NeoCardSettingsContentPropertySelect = ({
   const reportTypes = getReportTypes(extensions);
   const overridePropertyDisplayName =
     settings.overridePropertyDisplayName !== undefined ? settings.overridePropertyDisplayName : false;
+
+  // If the override is off, and the two values differ, set the display value to the original one again.
+  if (overridePropertyDisplayName == false && propertyInputText !== propertyInputDisplayText) {
+    onReportSettingUpdate('propertyTypeDisplay', settings.propertyType);
+    setPropertyInputDisplayText(propertyInputText);
+    updateReportQuery(settings.entityType, settings.propertyType, settings.propertyType);
+  }
 
   return (
     <div>

--- a/src/modal/AboutModal.tsx
+++ b/src/modal/AboutModal.tsx
@@ -10,7 +10,7 @@ import { Button } from '@material-ui/core';
 import BugReportIcon from '@material-ui/icons/BugReport';
 
 export const NeoAboutModal = ({ open, handleClose, getDebugState }) => {
-  const version = '2.2.2';
+  const version = '2.2.3';
 
   const downloadDebugFile = () => {
     const element = document.createElement('a');


### PR DESCRIPTION
## NeoDash 2.2.3
This releases fixes a small set of bugs that slipped through the 2.2.3 release, and adds some minor features:
- Added support for scatter plots by overriding a parameter in the line chart.
- Added the ability to use dashboard parameter as filters in custom parameter selector queries.
- Fixed breaking bug in parameter selector settings causing a white-screen error.
- Fixed auto-coloring of bar charts (resolved back to logic of 2.2.1 and earlier).
- Upversioned outdated dashboards and in the NeoDash Gallery.
