### PR TITLE
Resync

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/styles": "^4.11.4",
     "@mui/material": "^5.3.0",
     "@mui/x-data-grid": "5.10.0",
-    "@neo4j-cypher/react-codemirror": "^1.0.0-next.20",
+    "@neo4j-cypher/react-codemirror": "^1.0.0-next.21",
     "@nivo/bar": "^0.80.0",
     "@nivo/circle-packing": "^0.80.0",
     "@nivo/core": "^0.80.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
     "@babel/runtime" "^7.20.6"
     "@neo4j-cypher/antlr4-browser" "1.0.0-next.0"
 
-"@neo4j-cypher/codemirror@1.0.0-next.19":
-  version "1.0.0-next.19"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.19.tgz#799c3e666947180d1e3d133d681f0bb73b7106e9"
-  integrity sha512-KMIQvR+6EL3/HPyf986xAI2iBZJ5LQYLrNP3dg3FS6DRhxAsVAsKTeR4VEJqQ8HV8odIYaLctnwGkjJu3UGV/g==
+"@neo4j-cypher/codemirror@1.0.0-next.20":
+  version "1.0.0-next.20"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/codemirror/-/codemirror-1.0.0-next.20.tgz#e599197d5bcaa15f8d40cf2ecbe2eb42865866c8"
+  integrity sha512-938c20M/9ZQipS0PGfjY0i4knWhzx4tJIzivRfoJCkyE4N3XZDOtWIxTnufz508Sx8K6oailJu+8Sqh4XQc5XA==
   dependencies:
     "@babel/runtime" "^7.20.6"
     "@codemirror/autocomplete" "^6.3.4"
@@ -1900,13 +1900,13 @@
     lodash.find "^4.6.0"
     lodash.includes "^4.3.0"
 
-"@neo4j-cypher/react-codemirror@^1.0.0-next.20":
-  version "1.0.0-next.20"
-  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.20.tgz#f197cb9f8f27d77c1d6a9cadbffdb586d3eb167e"
-  integrity sha512-nZ5bLbAe+vaWxfA0bU8yT7cEDPtwX8S7x42AukrXRQHWM26bsSEQcxQXyI30JPg1hPuMlQDAr3rwiIFnMeY86Q==
+"@neo4j-cypher/react-codemirror@^1.0.0-next.21":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@neo4j-cypher/react-codemirror/-/react-codemirror-1.0.0-next.21.tgz#25a811627bcb3aa7013a97f9e72455161edd67b9"
+  integrity sha512-ew3VuO2zytLINBCHchJIAXTiz06kQx/siKKtFPYmmL2/zDhLUk3yO6/xA1gRpS/xNnSQ+xBvQaN9Aw0t13ZYqg==
   dependencies:
     "@babel/runtime" "^7.20.6"
-    "@neo4j-cypher/codemirror" "1.0.0-next.19"
+    "@neo4j-cypher/codemirror" "1.0.0-next.20"
     codemirror "^6.0.1"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":


### PR DESCRIPTION
* Master to dev Release (#259)

* TableChart : Auto-hide columns prefixed with __

* Master to dev Release (#259)

* Added prettier (config based on neo4j/nx repository)

* Added eslint and husky (config based on neo4j/nx repository)

* Updated eslint config to be as light as possible with Typescript

* Updated all files with prettier and linter, refactored files to avoid errors

* Added Eslint check step in Github workflows

* Updated all files with prettier and linter after rebase on Develop branch

* Squash Security Bumbs (#281)

* Bump loader-utils from 2.0.2 to 2.0.4 in /gallery

Bumps [loader-utils](https://github.com/webpack/loader-utils) from 2.0.2 to 2.0.4.
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v2.0.4/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v2.0.2...v2.0.4)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

* Bump loader-utils from 1.4.0 to 1.4.2

Bumps [loader-utils](https://github.com/webpack/loader-utils) from 1.4.0 to 1.4.2.
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v1.4.2/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v1.4.0...v1.4.2)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

* Update yarn.lock

* yarn gallery util 3.2.1

* bump

* remove lodash 4.17.15 lock

* remove minimatch 3.0.4 lock

* remove d3 color lock

* remove node.fet color lock

* ut

* no node fetch

* lod

* lod2

* ncheck

* d3 init

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Bump loader-utils from 2.0.2 to 2.0.4 in /gallery (#264)

Bumps [loader-utils](https://github.com/webpack/loader-utils) from 2.0.2 to 2.0.4.
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v2.0.4/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v2.0.2...v2.0.4)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Fixes #160 (#269)

* Fix : Replace parameter in iFrame URLs (#276)

* Fix : Replace parameter in iFrame URLs

* Fix wrong merge conflict

Co-authored-by: Marius Conjeaud <rmcj@novonordisk.com>

* Bump loader-utils from 2.0.2 to 2.0.4 in /gallery (#290)

* Bump loader-utils from 1.4.0 to 1.4.2 (#265)

Bumps [loader-utils](https://github.com/webpack/loader-utils) from 1.4.0 to 1.4.2.
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v1.4.2/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v1.4.0...v1.4.2)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Bump loader-utils from 2.0.2 to 2.0.4 in /gallery

Bumps [loader-utils](https://github.com/webpack/loader-utils) from 2.0.2 to 2.0.4.
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v2.0.4/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v2.0.2...v2.0.4)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Crash on Boolean options parameter selection (#285)

* bug on non string values

* Fix merge conflicts

* Fix merge conflicts

* Fix merge conflicts

* Fix merge conflicts

* Fix merge conflicts

Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Hotfix for Neo4j container issues with 5.3 (#293)

* Updated deployment scripts to use minimal build without source maps (#271)

* Changed build script to use mimimal (no source map) deployment

* Added TODOs based on comments

* Changing card image download logic  (#273)

* feature(): Changing download logic for card download by downloading the entire card instead of just the view. This kind of change adds also the buttons to the downloaded image, that is not ideal.

* fix(download report image): added missing ref for card expanded view

* Removed package-lock.json

Co-authored-by: Alfred Rubin <alfredo.rubin@neo4j.com>
Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Dynamic Card titles (#270)

* change of names

* Resolving conflicts

* Bug fix

* Refactoring

* Fixed replacement of params in card headers

Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Docs on custom map provider (#282)

* Docs on custom map provider

* Update docs/modules/ROOT/pages/user-guide/reports/map.adoc

Co-authored-by: MariusC <marius.conjeaud@outlook.com>

Co-authored-by: MariusC <marius.conjeaud@outlook.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Added release notes, bumped version number

* Fixed style issues introduced by 2.2.1 + some of the console warnings in development mode

* Some more minor style fixes in modal text

* Fixed unclear phrasing in extensions modal

* Added wine dashboard to gallery (#298)

* Added wine dashboard

* Updated wine dashboard in gallery

* Added jokes dashboard (#300)

* Added citation graph (#306)

* Bump json5 from 1.0.1 to 1.0.2 (#302)

Bumps [json5](https://github.com/json5/json5) from 1.0.1 to 1.0.2.
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v1.0.1...v1.0.2)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Bump json5 from 2.2.1 to 2.2.3 in /docs (#303)

Bumps [json5](https://github.com/json5/json5) from 2.2.1 to 2.2.3.
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v2.2.1...v2.2.3)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Bump json5 from 1.0.1 to 1.0.2 in /gallery (#304)

Bumps [json5](https://github.com/json5/json5) from 1.0.1 to 1.0.2.
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v1.0.1...v1.0.2)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Added assessment gallery

* Bump convict from 6.2.3 to 6.2.4 in /docs (#307)

Bumps [convict](https://github.com/mozilla/node-convict) from 6.2.3 to 6.2.4.
- [Release notes](https://github.com/mozilla/node-convict/releases)
- [Changelog](https://github.com/mozilla/node-convict/blob/master/CHANGELOG.md)
- [Commits](https://github.com/mozilla/node-convict/commits)

---
updated-dependencies:
- dependency-name: convict dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* use link (#295)

add  a link to the neodash repo

* upgrade to @neo4j-cypher/react-codemirror package (#286)

* upgrade to neo4j-cypher/react-codemirror package

* bump @neo4j-cypher/react-codemirror

* remove unused old cypher editor component

* fix integration tests (missing className)

* bump @neo4j-cypher/react-codemirror

* bump @neo4j-cypher/react-codemirror

* bump @neo4j-cypher/react-codemirror

* bump @neo4j-cypher/react-codemirror to latest

add codemirror markdown packages as an experiment

* enable switching between cypher/markdown languages

* update yarn.lock

* fix lint errors

* update @neo4j-cypher/react-codemirror to latest (fix line number text height)

* Fixed breaking integration tests

Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Added step to release pipeline to publish to neo4jlabs/neodash on Docker Hub (#299)

* Added new Docker image publish location

* Refactoring docs to point to new docker image location

* Fixed URL reference for gallery docs

* [Feature Request] Refresh button #166 (#277)

* [Feature Request] Refresh button #166

* [Feature Request] Refresh button #166

* Added conditional setting of last run timestamp

* Added option to turn on/off refreshing/download/fullscreening for each report

* enabled refreshing/fullscreening/image download on a per report basis

* Moved refresh rate, fullscreening, and screenshots to advanced settings for each report

* Disabled database selector for text/markdown reports

Co-authored-by: Marius Conjeaud <rmcj@novonordisk.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Bump @neo4j-cypher/react-codemirror to pre 18 (#309)

* update @neo4j-cypher/react-codemirror for bugfix

fixes a bug where syntax highlighting markers weren't being cleared properly

* oops use ^ in package version

* bump again for pre-release 19

* condensed display for tables #167 (#278)

* condensed display for tables #167

* condensed display for tables #167

* #167 Fix half-displayed row in compact table

* Fix overflowing row for compact table

* Added safe boolean checking for compaction setting

Co-authored-by: Marius Conjeaud <rmcj@novonordisk.com>
Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* update editor for minification bugfix (constructor.name) (#311)

* Fixed doc page title

* Added instructions on deploying a buildt to a webserver

* Isoa3, a2 and n3 support (#284)

* Isoa3, a2 and n3 support

* Changed choropleth polymap source to neodash repository

Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Added error boundary for reports (#313)

* Added error boundary for reports

* Minor correction in README

* More small changes to the README

* More small changes to the README

* Added release notes, bumped version number

* Parameter Selector Display option (#274)

* Selector display vs value

* extra changes . some test changes

* Fix typo

* FIx on Parameter selec

* Minor style fixes

---------

Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Feature/style with parameters (#330)

* StyleWithParams

* Stability fixes for rule-based styling on parameters

* Fix for rule-based styling in graph charts

---------

Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Feature/rule based styling on top of scheme (#331)

* Added utils for chart colors and updated coloring function in PieChart component

* on bars

* Reuse existing color util instead of new one

---------

Co-authored-by: “Bastien <“bastien.hubert@hotmail.com”>
Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Refactoring the parameter selector chart and updating MUI component (#301)

* Refactoring the parameter selector chart and updating MUI component version

* Continued refactoring of parameter selector component

* Finished refactoring of parameters. Also fixed the weird bug where values were set incorrectly

* updated release notes

* Refactoring based on the new parameter display values

* Finished refactor and merging of parameter display setting

* Updated release notes again

* finalized changelog and release notes

* Fixed typo in about modal screen

* Stacked Bars Colors Fix (#343)

* Stacked Bars COlors FIx

* Workaround source map warning

* No multicolor on singles

* fix on long lists

* Fixed bug in manual label name specification of param selector (#344)

* Passed all dashboard parameters to parameter populating query

* Bump http-cache-semantics from 4.1.0 to 4.1.1 (#334)

Bumps [http-cache-semantics](https://github.com/kornelski/http-cache-semantics) from 4.1.0 to 4.1.1.
- [Release notes](https://github.com/kornelski/http-cache-semantics/releases)
- [Commits](https://github.com/kornelski/http-cache-semantics/commits)

---
updated-dependencies:
- dependency-name: http-cache-semantics dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Harold Agudelo <agudeloharold13@gmail.com>
Co-authored-by: Niels de Jong <Niels-121@hotmail.com>

* Fix for numbers. (#346)

* Scatter plot (#341)

* Scatter plot

Add advanced setting to line charts to turn it into a scatter plot

* Scatter plot

Add advanced setting to line charts to turn it into a scatter plot

* Added docs and refactored settings retrieval

---------

Co-authored-by: Harold Agudelo <agudeloharold13@gmail.com>
Co-authored-by: Niels de Jong <niels-121@hotmail.com>

* Added release notes for 2.2.3 (#348)

* Added release notes for 2.2.3

* Added release notes for 2.2.3

* Added fix for link parsing in documentation portal

* Quickfix for auto-resetting param display text when advanced setting is toggled

* Updated release notes

* Bumped Cypher editor version

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Harold Agudelo <agudeloharold13@gmail.com>
Co-authored-by: Marius Conjeaud <rmcj@novonordisk.com>
Co-authored-by: “Bastien <“bastien.hubert@hotmail.com”>
Co-authored-by: Bastien Hubert <43408420+bastienhubert@users.noreply.github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Neil Menezes <37837480+skoarkid@users.noreply.github.com>
Co-authored-by: MariusC <marius.conjeaud@outlook.com>
Co-authored-by: alfredorubin96 <103421036+alfredorubin96@users.noreply.github.com>
Co-authored-by: Alfred Rubin <alfredo.rubin@neo4j.com>
Co-authored-by: ioilmio <Illuminato.salvatore@gmail.com>
Co-authored-by: Jon Harris <harris.jb@gmail.com>
Co-authored-by: Jon Ander Oribe <jonan.oribe@gmail.com>