### PR TITLE
Fixed invalid secret being used to publish docker image

### DIFF
--- a/.github/workflows/master-deployment.yml
+++ b/.github/workflows/master-deployment.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LABS_ACCESS_TOKEN }}
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v1
       - name: Build and push
@@ -79,7 +79,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_USERNAME }}/neodash:2.3.0
+          tags: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:2.3.0
   build-docker-legacy:
     needs: build-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docker image for 2.3.0 was only published to `nielsdejong/neodash` (legacy) and not `neo4jlabs/neodash`.
This PR fixes that issue.