### PR TITLE
VULCAN-133/Adding a legend button for relationships and nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@codemirror/lang-markdown": "^6.1.1",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^7.0.2",
+    "@mui/icons-material": "^5.14.3",
     "@mui/material": "^5.12.3",
     "@mui/styles": "^5.12.3",
     "@mui/x-data-grid": "5.17.26",
@@ -115,6 +116,7 @@
     "@typescript-eslint/parser": "^5.42.0",
     "babel-loader": "^8.2.3",
     "babel-plugin-istanbul": "^6.1.1",
+    "circular-dependency-plugin": "^5.2.2",
     "css-loader": "^3.6.0",
     "cypress": "^10.11.0",
     "eslint": "^8.26.0",
@@ -134,7 +136,6 @@
     "typescript": "^4.8.4",
     "webpack": "^5.77.0",
     "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.7.3",
-    "circular-dependency-plugin": "^5.2.2"
+    "webpack-dev-server": "^4.7.3"
   }
 }

--- a/src/card/Card.tsx
+++ b/src/card/Card.tsx
@@ -102,7 +102,6 @@ const NeoCard = ({
   const [active, setActive] = React.useState(
     report.settings && report.settings.autorun !== undefined ? report.settings.autorun : true
   );
-
   useEffect(() => {
     if (!report.settingsOpen) {
       setActive(report.settings && report.settings.autorun !== undefined ? report.settings.autorun : true);
@@ -116,6 +115,15 @@ const NeoCard = ({
   useEffect(() => {
     setCollapseTimeout(report.collapseTimeout);
   }, [report.collapseTimeout]);
+
+  const [legendDefinition, setLegendDefinition] = React.useState(report.settings?.legendDefinition);
+
+  useEffect(() => {
+    if (!report.settings.legendDefinition) {
+      return;
+    }
+    setLegendDefinition(report.settings?.legendDefinition);
+  }, [report.settings.legendDefinition]);
 
   // TODO - get rid of some of the props-drilling here...
   const component = (
@@ -158,6 +166,7 @@ const NeoCard = ({
               setCollapseTimeout('auto');
               debouncedOnToggleCardSettings(id, true);
             }}
+            legendDefinition={legendDefinition}
           />
         </Card>
       </Collapse>

--- a/src/card/view/CardView.tsx
+++ b/src/card/view/CardView.tsx
@@ -23,6 +23,7 @@ const NeoCardView = ({
   heightPx,
   fields,
   extensions,
+  legendDefinition,
   active,
   setActive,
   onDownloadImage,
@@ -171,6 +172,7 @@ const NeoCardView = ({
           expanded={expanded}
           rowLimit={dashboardSettings.disableRowLimiting ? 1000000 : reportTypes[type] && reportTypes[type].maxRecords}
           dimensions={{ width: widthPx, height: heightPx }}
+          legendDefinition={legendDefinition}
           type={type}
           ChartType={reportTypes[type] && reportTypes[type].component}
           setGlobalParameter={onGlobalParameterUpdate}

--- a/src/chart/Chart.ts
+++ b/src/chart/Chart.ts
@@ -19,6 +19,7 @@ export interface ChartProps {
   updateReportSetting?: (name, value) => void; // Callback to update a setting for this report.
   fields: (fields) => string[]; // List of fields (return values) available for the report.
   setFields?: (fields) => void; // Update the list of fields for this report.
+  legendDefinition?: object;
   theme?: string; // Dashboard theme value.
 }
 

--- a/src/chart/graph/GraphChart.tsx
+++ b/src/chart/graph/GraphChart.tsx
@@ -13,13 +13,14 @@ import { GraphChartVisualizationProps, layouts } from './GraphChartVisualization
 import { handleExpand } from './util/ExplorationUtils';
 import { categoricalColorSchemes } from '../../config/ColorConfig';
 import { IconButtonArray, IconButton } from '@neo4j-ndl/react';
-import { Tooltip } from '@mui/material';
+import { Stack, Tooltip } from '@mui/material';
 import { downloadCSV } from '../ChartUtils';
 import { generateSafeColumnKey } from '../table/TableChart';
 import { GraphChartContextMenu } from './component/GraphChartContextMenu';
 import { getSettings } from '../SettingsUtils';
 import { getPageNumbersAndNamesList } from '../../extensions/advancedcharts/Utils';
 import { CloudArrowDownIconOutline } from '@neo4j-ndl/react/icons';
+import { NeoGraphChartLegendButton } from './component/button/GraphChartLegendButton';
 
 /**
  * Draws graph data using a force-directed-graph visualization.
@@ -137,6 +138,7 @@ const NeoGraphChart = (props: ChartProps) => {
       setLinks: setLinks,
       setNodeLabels: setNodeLabels,
       setLinkTypes: setLinkTypes,
+      legendDefinition: props.legendDefinition ? props.legendDefinition : {},
     },
     style: {
       width: width,
@@ -217,17 +219,20 @@ const NeoGraphChart = (props: ChartProps) => {
   return (
     <div ref={observe} style={{ width: '100%', height: '95%' }}>
       <NeoGraphChartCanvas>
-        <IconButtonArray
-          aria-label={'graph icon'}
-          floating
-          orientation='horizontal'
-          className='n-z-10 n-absolute n-bottom-2 n-right-4'
-        >
-          <GraphChartContextMenu {...chartProps} />
-          <NeoGraphChartFitViewButton {...chartProps} />
-          {settings.lockable ? <NeoGraphChartLockButton {...chartProps} /> : <></>}
-          {settings.drilldownLink ? <NeoGraphChartDeepLinkButton {...chartProps} /> : <></>}
-        </IconButtonArray>
+        <Stack direction={'row'}>
+          <NeoGraphChartLegendButton {...chartProps}></NeoGraphChartLegendButton>
+          <IconButtonArray
+            aria-label={'graph icon'}
+            floating
+            orientation='horizontal'
+            className='n-z-10 n-absolute n-bottom-2 n-right-4'
+          >
+            <GraphChartContextMenu {...chartProps} />
+            <NeoGraphChartFitViewButton {...chartProps} />
+            {settings.lockable ? <NeoGraphChartLockButton {...chartProps} /> : <></>}
+            {settings.drilldownLink ? <NeoGraphChartDeepLinkButton {...chartProps} /> : <></>}
+          </IconButtonArray>
+        </Stack>
         <NeoGraphChartVisualization2D {...chartProps} />
         <NeoGraphChartInspectModal {...chartProps}></NeoGraphChartInspectModal>
         {settings.allowDownload && props.records && props.records.length > 0 ? (

--- a/src/chart/graph/GraphChartVisualization.ts
+++ b/src/chart/graph/GraphChartVisualization.ts
@@ -58,6 +58,7 @@ export interface GraphChartVisualizationProps {
     setLinks: (links) => void;
     setNodeLabels: (labels) => void;
     setLinkTypes: (types) => void;
+    legendDefinition: object;
   };
   /**
    * The properties relevant for styling the graph.

--- a/src/chart/graph/component/button/GraphChartLegendButton.tsx
+++ b/src/chart/graph/component/button/GraphChartLegendButton.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Box, Button, List, ListItem, ListItemText, Popover, Tooltip, Typography } from '@mui/material';
+import { GraphChartVisualizationProps } from '../../GraphChartVisualization';
+import { CircleIcon } from '@neo4j-ndl/react/icons';
+import { ArrowForwardRounded } from '@mui/icons-material';
+
+/**
+ * Renders an icon on the bottom-right of the graph visualization to fit the current graph to the user's view.
+ */
+export const NeoGraphChartLegendButton = (props: GraphChartVisualizationProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+
+  const [legendOpen, setLegendOpen] = React.useState(false);
+  const [legendEnabled, setLegendEnabled] = React.useState(false);
+  const [legendEntries, setLegendEntries] = React.useState(props.data?.legendDefinition);
+
+  React.useEffect(() => {
+    let legendEntryList: object[] = [];
+
+    Object.values(props.data.legendDefinition).forEach((legendDefinition) => {
+      if (legendDefinition.enabled === true && legendDefinition.entries.length > 0) {
+        setLegendEnabled(true);
+        legendDefinition.entries.forEach((entry) => legendEntryList.push(entry));
+      }
+      setLegendEntries(legendEntryList);
+    });
+  }, [props.data.legendDefinition]);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+    setLegendOpen(!legendOpen);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+    setLegendOpen(false);
+  };
+
+  const getNodeLegend = (legendEntries) => {
+    return legendEntries.length > 0 ? (
+      <List dense={true} disablePadding={true}>
+        {legendEntries.map((entry) => {
+          return (
+            <ListItem
+              alignItems='center'
+              disablePadding={true}
+              disableGutters={true}
+              style={{ marginLeft: '0.2rem', marginRight: '0.5rem' }}
+              key={entry}
+            >
+              <Typography
+                padding-left='0.5rem'
+                variant='h4'
+                sx={{
+                  width: '1.5rem',
+                  display: entry.type === 'node' ? 'flex' : 'none',
+                  alignItems: 'center',
+                }}
+              >
+                <CircleIcon color={entry.color} />
+              </Typography>
+              <Typography
+                padding-left='0.5rem'
+                variant='h4'
+                sx={{ width: '1.5rem', display: entry.type === 'edge' ? 'flex' : 'none', alignItems: 'center' }}
+              >
+                <ArrowForwardRounded htmlColor={entry.color} />
+              </Typography>
+              <ListItemText
+                sx={{ paddingLeft: '0.5rem' }}
+                primary={entry.meaning}
+                primaryTypographyProps={{
+                  color: entry.textColor,
+                  variant: 'body2',
+                }}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+    ) : (
+      <></>
+    );
+  };
+  return (
+    <>
+      <Button
+        color='primary'
+        size='small'
+        onClick={handleClick}
+        style={{
+          display: !legendEnabled ? 'none' : '',
+          position: 'absolute',
+          background: 'white',
+          bottom: '15px',
+          left: '0px',
+          zIndex: '50',
+        }}
+      >
+        <Tooltip title='Show legend' aria-label={'show Legend'}>
+          <Box
+            sx={{
+              paddingRight: '2pt',
+              paddingLeft: '2pt',
+              borderColor: '#EAECEE',
+              borderWidth: '1pt',
+              typography: 'subtitle2',
+              textTransform: 'capitalize',
+            }}
+          >
+            Legend
+          </Box>
+        </Tooltip>
+      </Button>
+      <Popover
+        open={legendOpen}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        <Typography
+          align='center'
+          variant='subtitle2'
+          gutterBottom={false}
+          sx={{
+            p: 1,
+            padding: 0,
+            marginTop: '0.2rem',
+            fontWeight: 'bold',
+          }}
+        >
+          LEGEND
+        </Typography>
+        {getNodeLegend(legendEntries)}
+      </Popover>
+    </>
+  );
+};

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -1,12 +1,10 @@
 import { Chip, Tooltip } from '@mui/material';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { QueryStatus, runCypherQuery } from './ReportQueryRunner';
 import debounce from 'lodash/debounce';
-import { useCallback } from 'react';
 import NeoCodeViewerComponent, { NoDrawableDataErrorMessage } from '../component/editor/CodeViewerComponent';
 import { DEFAULT_ROW_LIMIT, HARD_ROW_LIMITING, RUN_QUERY_DELAY_MS } from '../config/ReportConfig';
 import { Neo4jContext, Neo4jContextState } from 'use-neo4j/dist/neo4j.context';
-import { useContext } from 'react';
 import NeoTableChart from '../chart/table/TableChart';
 import { getReportTypes } from '../extensions/ExtensionUtils';
 import { SELECTION_TYPES } from '../config/CardConfig';
@@ -51,6 +49,7 @@ export const NeoReport = ({
   type = 'table', // The type of report as a string.
   expanded = false, // whether the report is visualized in a fullscreen view.
   extensions = {}, // A set of enabled extensions.
+  legendDefinition = {},
   getCustomDispatcher = () => {},
   ChartType = NeoTableChart, // The report component to render with the query results.
   prepopulateExtensionName,
@@ -279,6 +278,7 @@ export const NeoReport = ({
           fields={fields}
           setFields={setFields}
           theme={theme}
+          legendDefinition={legendDefinition}
         />
       </div>
     );
@@ -320,6 +320,7 @@ export const NeoReport = ({
           updateReportSetting={updateReportSetting}
           fields={fields}
           setFields={setFields}
+          legendDefinition={legendDefinition}
         />
       </div>
     );

--- a/src/report/ReportWrapper.tsx
+++ b/src/report/ReportWrapper.tsx
@@ -46,6 +46,7 @@ export const NeoReportWrapper = ({
   type,
   expanded,
   extensions,
+  legendDefinition,
   ChartType,
 }) => {
   return (
@@ -71,6 +72,7 @@ export const NeoReportWrapper = ({
         type={type}
         expanded={expanded}
         extensions={extensions}
+        legendDefinition={legendDefinition}
         ChartType={ChartType}
       />
     </ErrorBoundary>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.22.6":
+  version "7.22.10"
+  resolved "https://pkgs.dev.azure.com/daimler-mic/_packaging/mercedes-developer-experience/npm/registry/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha1-rj6WMf2UfLfjYQ0+nY/vX3ZpZoI=
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2316,6 +2323,13 @@
   version "5.12.3"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.3.tgz#3dffe62dccc065ddd7338e97d7be4b917004287e"
   integrity sha512-yiJZ+knaknPHuRKhRk4L6XiwppwkAahVal3LuYpvBH7GkA2g+D9WLEXOEnNYtVFUggyKf6fWGLGnx0iqzkU5YA==
+
+"@mui/icons-material@^5.14.3":
+  version "5.14.3"
+  resolved "https://pkgs.dev.azure.com/daimler-mic/_packaging/mercedes-developer-experience/npm/registry/@mui/icons-material/-/icons-material-5.14.3.tgz#26a84d52ab2fceea2856adf7a139527b3a51ae90"
+  integrity sha1-JqhNUqsvzuooVq33oTlSezpRrpA=
+  dependencies:
+    "@babel/runtime" "^7.22.6"
 
 "@mui/material@^5.12.3":
   version "5.12.3"
@@ -11861,6 +11875,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://pkgs.dev.azure.com/daimler-mic/_packaging/mercedes-developer-experience/npm/registry/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha1-XhnWjrEtSG95fhWjxqkY987F60U=
 
 regenerator-transform@^0.15.1:
   version "0.15.1"


### PR DESCRIPTION
Added a legend button that can be configured such in the dashboard JSON: 

"settings": {
            "minimizable": "on",
            "nodePositions": {},
            "nodeLabelFontSize": 3,
            "relLabelFontSize": 2,
            "backgroundColor": "#ffffff",
            "hideSelections": true,
            "refreshButtonEnabled": true,
            "fullscreenEnabled": true,
            "downloadImageEnabled": true,
            "legendDefinition": [
              {
                "enabled": true,
                "entries": [
                  {
                    "type": "node",
                    "color": "#EFE289",
                    "meaning": "SW version",
                    "textColor": "#000000"
                  },
                  {
                    "type": "edge",
                    "color": "#4caf50",
                    "meaning": "HW version",
                    "textColor": "#000000"
                  }
                ]
              }
            ],

The program was tested solely for our own use cases, which might differ from yours. 

Brahm Prakash Mishra <brahm.praksh_mishra@mercedes-benz.com> on behalf of Mercedes-Benz Research and Development India.
![2023-08-22 06 49 01](https://github.com/neo4j-labs/neodash/assets/134035157/f665e4ed-a9b9-45a3-8528-40fb7323271f)


[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)