### PR TITLE
Adding a table cell option that will expand on hover

### DIFF
--- a/src/chart/table/TableChart.tsx
+++ b/src/chart/table/TableChart.tsx
@@ -22,6 +22,7 @@ import { CloudArrowDownIconOutline, XMarkIconOutline } from '@neo4j-ndl/react/ic
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { extensionEnabled } from '../../utils/ReportUtils';
+import { renderCellExpand } from '../../component/misc/DataGridExpandRenderer';
 
 const TABLE_HEADER_HEIGHT = 32;
 const TABLE_FOOTER_HEIGHT = 62;
@@ -34,6 +35,10 @@ const theme = createTheme({
     allVariants: { color: 'rgb(var(--palette-neutral-text-default))' },
   },
 });
+
+const expandedCellRenderer = (value, lineBreaksAfterListEntry) => {
+  return renderCellExpand(value, lineBreaksAfterListEntry);
+};
 const fallbackRenderer = (value) => {
   return JSON.stringify(value);
 };
@@ -50,9 +55,14 @@ function renderAsButtonWrapper(renderer) {
   };
 }
 
-function ApplyColumnType(column, value, asAction) {
+function ApplyColumnType(column, value, asAction, useExpandedRenderer) {
   const renderer = getRendererForValue(value);
-  const renderCell = asAction ? renderAsButtonWrapper(renderer.renderValue) : renderer.renderValue;
+  const renderCell = useExpandedRenderer
+    ? (obj) => expandedCellRenderer(obj, column.lineBreakAfterListEntry)
+    : asAction
+    ? renderAsButtonWrapper(renderer.renderValue)
+    : renderer.renderValue;
+
   const columnProperties = renderer
     ? { type: renderer.type, renderCell: renderCell ? renderCell : fallbackRenderer }
     : rendererForType.string;
@@ -78,7 +88,7 @@ export const NeoTableChart = (props: ChartProps) => {
   const compact = props.settings && props.settings.compact !== undefined ? props.settings.compact : false;
   const styleRules = useStyleRules(
     extensionEnabled(props.extensions, 'styling'),
-    props.settings.styleRules,
+    props.settings?.styleRules,
     props.getGlobalParameter
   );
 
@@ -89,6 +99,8 @@ export const NeoTableChart = (props: ChartProps) => {
   if (props.records == null || props.records.length == 0 || props.records[0].keys == null) {
     return <>No data, re-run the report.</>;
   }
+
+  const useExpandedRenderer = props.settings?.expandedCellRenderer;
 
   const tableRowHeight = compact ? TABLE_ROW_HEIGHT / 2 : TABLE_ROW_HEIGHT;
   const pageSizeReducer = compact ? 3 : 1;
@@ -110,6 +122,8 @@ export const NeoTableChart = (props: ChartProps) => {
     return key != 'id' ? key : `${key} `;
   };
 
+  const lineBreakColumns: string[] = props.settings?.lineBreaksAfterListEntry;
+
   const actionableFields = actionsRules.map((r) => r.field);
 
   const columns = transposed
@@ -126,7 +140,8 @@ export const NeoTableChart = (props: ChartProps) => {
             disableClickEventBubbling: true,
           },
           key,
-          actionableFields.includes(key)
+          actionableFields.includes(key),
+          useExpandedRenderer
         );
       })
     : records[0].keys.map((key, i) => {
@@ -141,9 +156,11 @@ export const NeoTableChart = (props: ChartProps) => {
               disableColumnSelector: true,
               flex: columnWidths && i < columnWidths.length ? columnWidths[i] : 1,
               disableClickEventBubbling: true,
+              lineBreakAfterListEntry: lineBreakColumns?.includes(key.toString()),
             },
             value,
-            actionableFields.includes(key)
+            actionableFields.includes(key),
+            useExpandedRenderer
           );
         }
         return ApplyColumnType(
@@ -155,9 +172,11 @@ export const NeoTableChart = (props: ChartProps) => {
             disableColumnSelector: true,
             width: columnWidths && i < columnWidths.length ? columnWidths[i] : 100,
             disableClickEventBubbling: true,
+            lineBreakAfterListEntry: lineBreakColumns?.includes(key.toString()),
           },
           value,
-          actionableFields.includes(key)
+          actionableFields.includes(key),
+          useExpandedRenderer
         );
       });
   const hiddenColumns = Object.assign(
@@ -252,9 +271,9 @@ export const NeoTableChart = (props: ChartProps) => {
         <DataGrid
           key={'tableKey'}
           headerHeight={32}
-          rowHeight={tableRowHeight}
           rows={rows}
           columns={columns}
+          density={compact === 'on' || compact === true ? 'compact' : 'standard'}
           columnVisibilityModel={hiddenColumns}
           onCellClick={(e) =>
             performActionOnElement(e, actionsRules, { ...props, pageNames: pageNames }, 'Click', 'Table')
@@ -268,8 +287,9 @@ export const NeoTableChart = (props: ChartProps) => {
               navigator.clipboard.writeText(e.value);
             }
           }}
-          pageSize={tablePageSize > 0 ? tablePageSize : 5}
-          rowsPerPageOptions={rows.length < 5 ? [rows.length, 5] : [5]}
+          autoPageSize
+          pagination
+          rowsPerPageOptions={[5]}
           disableSelectionOnClick
           components={{
             ColumnSortedDescendingIcon: () => <></>,

--- a/src/component/misc/DataGridExpandRenderer.tsx
+++ b/src/component/misc/DataGridExpandRenderer.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { Paper, Popper, Typography } from '@mui/material';
+import { GridRenderCellParams } from '@mui/x-data-grid';
+import { useEffect } from 'react';
+
+interface GridCellExpandProps {
+  value: string;
+  width: number;
+}
+
+function isOverflown(element: Element): boolean {
+  return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
+}
+
+const GridCellExpand = React.memo((props: GridCellExpandProps) => {
+  const { width, value } = props;
+  const wrapper = React.useRef<HTMLDivElement | null>(null);
+  const cellDiv = React.useRef(null);
+  const cellValue = React.useRef(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [showFullCell, setShowFullCell] = React.useState(false);
+  const [showPopper, setShowPopper] = React.useState(false);
+
+  const handleMouseEnter = () => {
+    const isCurrentlyOverflown = isOverflown(cellValue.current!);
+    setShowPopper(isCurrentlyOverflown);
+    setAnchorEl(cellDiv.current);
+    setShowFullCell(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowFullCell(false);
+  };
+
+  React.useEffect(() => {
+    if (!showFullCell) {
+      return undefined;
+    }
+
+    function handleKeyDown(nativeEvent: KeyboardEvent) {
+      // IE11, Edge (prior to using Bink?) use 'Esc'
+      if (nativeEvent.key === 'Escape' || nativeEvent.key === 'Esc') {
+        setShowFullCell(false);
+      } else if (nativeEvent.key.toLocaleLowerCase() === 'c' && (nativeEvent.ctrlKey || nativeEvent.metaKey === true)) {
+        navigator.clipboard.writeText(value);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [setShowFullCell, showFullCell]);
+
+  return (
+    <Box
+      ref={wrapper}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      sx={{
+        alignItems: 'center',
+        lineHeight: '24px',
+        width: '100%',
+        height: 'fit-content!imporant!',
+        position: 'relative',
+        display: 'flex',
+      }}
+    >
+      <Box
+        ref={cellDiv}
+        sx={{
+          height: 'fit-content!imporant!',
+          width,
+          display: '-webkit-box',
+          position: 'absolute',
+          top: 0,
+        }}
+      />
+      <Box
+        ref={cellValue}
+        sx={{
+          whiteSpace: 'break-spaces',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: '-webkit-box',
+          WebkitLineClamp: '2',
+          WebkitBoxOrient: 'vertical',
+        }}
+      >
+        {value}
+      </Box>
+      {showPopper && (
+        <Popper open={showFullCell && anchorEl !== null} anchorEl={anchorEl} style={{ width, marginLeft: -17 }}>
+          <Paper elevation={1} style={{ minHeight: wrapper.current!.offsetHeight - 3 }}>
+            <Typography variant='body2' style={{ padding: 8, whiteSpace: 'normal', wordBreak: 'break-word' }}>
+              {value}
+            </Typography>
+          </Paper>
+        </Popper>
+      )}
+    </Box>
+  );
+});
+
+export function renderCellExpand(params: GridRenderCellParams<any, string>, lineBreakAfterListEntry: boolean) {
+  let [value, setValue] = React.useState(params.value);
+  useEffect(() => {
+    if (value?.low) {
+      setValue(value.low);
+    }
+  }, [params]);
+
+  const stringifiedObj = value
+    ? JSON.stringify(value)
+        .replaceAll(',', lineBreakAfterListEntry ? ',\r\n' : ', ') // TODO: Consolidate to a regex
+        .replaceAll(']', '')
+        .replaceAll('[', '')
+        .replaceAll('"', '')
+    : '';
+
+  return <GridCellExpand value={stringifiedObj || ''} width={params.colDef.computedWidth} />;
+}

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -101,6 +101,12 @@ export const REPORT_TYPES = {
         type: SELECTION_TYPES.MULTILINE_TEXT,
         default: 'Enter markdown here...',
       },
+      expandedCellRenderer: {
+        label: 'Use expanded cell renderer',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
     },
   },
   graph: {


### PR DESCRIPTION
This can be optionally used to have an expandable view in tables where cell content overflows given table width. 
A dashboard json defined as such:
![Screenshot 2023-08-24 at 5 38 02 PM](https://github.com/neo4j-labs/neodash/assets/134035157/60eff9f5-6720-4512-a3d4-491e31f2a29d)

Creates below view in the dashboards:
![2023-08-24 17 48 41](https://github.com/neo4j-labs/neodash/assets/134035157/b1ab815b-172d-437d-852e-26331d1c0a1c)

Features to be noted:
Expanded cell renderer creates a '2 line' view in the tables by default (so more data fits) but if data overflows even that, a popup is displayed on hover. 

The program was tested solely for our own use cases, which might differ from yours.

Brahm Prakash Mishra [brahm.praksh_mishra@mercedes-benz.com](mailto:brahm.praksh_mishra@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India.

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)