### PR TITLE
Vulcan 223/blank space after comma relationship table

### DIFF
--- a/src/chart/graph/component/GraphEntityInspectionTable.tsx
+++ b/src/chart/graph/component/GraphEntityInspectionTable.tsx
@@ -11,7 +11,7 @@ export const formatProperty = (property) => {
       </TextLink>
     );
   }
-  return property.split(',').join(', ');
+  return property.replace(/,(?=[^\s])/g, ", ");
 };
 
 /**

--- a/src/chart/graph/component/GraphEntityInspectionTable.tsx
+++ b/src/chart/graph/component/GraphEntityInspectionTable.tsx
@@ -11,7 +11,7 @@ export const formatProperty = (property) => {
       </TextLink>
     );
   }
-  return property;
+  return property.split(',').join(', ');
 };
 
 /**


### PR DESCRIPTION
In the comma separated list that shows up in detail view, a space after comma is missing (even from existing neodash versions). Therefore, this is a small PR to replace the generated comma separated string with comma-space, if there is no whitespace after any comma.

The program was tested solely for our own use cases, which might differ from yours.

On behalf of Deverajan Murugesan, [deverajan.murugesan@mercedes-benz.com](mailto:devarajan.murugesan@mercedes-benz.com), who has in turn has made this change on behalf of Mercedes-Benz Research and Development India.

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)