### PR TITLE
VULCAN-132/Clear parameter value of Parameter select chart on tab change

### DIFF
--- a/src/chart/parameter/ParameterSelectionChart.tsx
+++ b/src/chart/parameter/ParameterSelectionChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ChartProps } from '../Chart';
 import DatePickerParameterSelectComponent from './component/DateParameterSelect';
 import NodePropertyParameterSelectComponent from './component/NodePropertyParameterSelect';
@@ -14,6 +14,7 @@ export const NeoParameterSelectionChart = (props: ChartProps) => {
   const query = props.records[0].input ? props.records[0].input : undefined;
   const parameterName = props.settings && props.settings.parameterName ? props.settings.parameterName : undefined;
   const parameterDisplayName = `${parameterName}_display`;
+  const clearParameterValueOnTabChange = props.settings && props.settings.clearParameterValueOnTabChange;
   const type = props.settings && props.settings.type ? props.settings.type : undefined;
   const queryCallback = props.queryCallback ? props.queryCallback : () => {};
   const setGlobalParameter = props.setGlobalParameter ? props.setGlobalParameter : () => {};
@@ -36,6 +37,16 @@ export const NeoParameterSelectionChart = (props: ChartProps) => {
   if (!query || query.trim().length == 0) {
     return <p style={{ margin: '15px' }}>No selection specified.</p>;
   }
+
+  // When Component unmounts based on clearParameterValueOnTabChange parameter value is set to empty.
+  // clearParameterValueOnTabChange can be configured in settings
+  useEffect(() => {
+    return () => {
+      if (clearParameterValueOnTabChange) {
+        setGlobalParameter(parameterName, '');
+      }
+    };
+  }, []);
 
   const theme = createTheme({
     typography: {

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -1290,6 +1290,12 @@ export const REPORT_TYPES = {
         type: SELECTION_TYPES.COLOR,
         default: '#fafafa',
       },
+      clearParameterValueOnTabChange: {
+        label: 'Clear parameter value on tab change',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
       multiSelector: {
         label: 'Multiple Selection',
         type: SELECTION_TYPES.LIST,


### PR DESCRIPTION
**Problem**
Parameter select reports allow interactivity as users can select parameters/values from the autocomplete dropdown. When a parameter is selected, the selection stays active until the browser tab (that is, the dashboard) is closed, no matter if the dashboard tab is changed. So, my users wanted a functionality to set the parameter select chart type that gets cleared when there is a tab change.

**Solution**
Introduced a clearParameterValueOnTabChange boolean in settings. When this is enabled the value in the parameter is set to empty.

**Screenshot**
![clear parameter value on tab change](https://github.com/neo4j-labs/neodash/assets/139316519/1a73217e-0b18-43b6-936b-3bb0e0ac8f66)

**NOTICE:**
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
