### PR TITLE
Replace hardcoded subpath with window.location.pathname

### DIFF
--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -124,7 +124,7 @@ export const createConnectionThunk =
         query,
         parameters,
         1,
-        () => {},
+        () => { },
         (records) => validateConnection(records)
       );
     } catch (e) {
@@ -254,7 +254,7 @@ export const handleSharedDashboardsThunk = () => (dispatch: any) => {
           dispatch(onConfirmLoadSharedDashboardThunk());
         }
 
-        window.history.pushState({}, document.title, '/');
+        window.history.pushState({}, document.title, window.location.pathname);
       } else {
         dispatch(setConnectionModalOpen(false));
         // dispatch(setWelcomeScreenOpen(false));
@@ -273,7 +273,7 @@ export const handleSharedDashboardsThunk = () => (dispatch: any) => {
             false
           )
         );
-        window.history.pushState({}, document.title, '/');
+        window.history.pushState({}, document.title, window.location.pathname);
       }
     } else {
       // dispatch(resetShareDetails());


### PR DESCRIPTION
**Problem**
Neodash frontend will be served from subpath. eg., https://mercedes-benz.com/neodash/ui/. So in shared dashboard after loading the credentials the page reloads and subpaths are gone. Because of this logo and favicon is not loaded in UI.

**Solution**
Replaced the path with window.location.pathname

**NOTICE:**
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)