### PR TITLE
#Vulcan-234/Show details button on node right click for Graph charts.

### DIFF
--- a/src/chart/graph/GraphChart.tsx
+++ b/src/chart/graph/GraphChart.tsx
@@ -202,6 +202,7 @@ const NeoGraphChart = (props: ChartProps) => {
       clickPosition: clickPosition,
       setClickPosition: setClickPosition,
       createNotification: props.createNotification,
+      pageIdAndParameterName: settings.pageIdAndParameterName,
     },
     extensions: {
       styleRules: settings.styleRules,

--- a/src/chart/graph/GraphChartVisualization.ts
+++ b/src/chart/graph/GraphChartVisualization.ts
@@ -134,6 +134,7 @@ export interface GraphChartVisualizationProps {
     setClickPosition: (pos) => void;
     setPageNumber: any;
     pageNames: [];
+    pageIdAndParameterName: string
   };
   /**
    * entries in 'extensions' let users plug in extra functionality into the visualization based on enabled plugins.

--- a/src/chart/graph/component/GraphChartContextMenu.tsx
+++ b/src/chart/graph/component/GraphChartContextMenu.tsx
@@ -12,6 +12,7 @@ import { handleExpand, handleGetNodeRelTypes } from '../util/ExplorationUtils';
 import { useEffect } from 'react';
 import { mergeDatabaseStatCountsWithCountsInView } from '../util/ExplorationUtils';
 import { createPortal } from 'react-dom';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 /**
  * Renders the context menu that is present when a user right clicks on a node or relationship in the graph.
@@ -29,6 +30,8 @@ export const GraphChartContextMenu = (props: GraphChartVisualizationProps) => {
   const dialogProps = { ...props, selectedNode: editableEntity, dialogOpen: dialogOpen, setDialogOpen: setDialogOpen };
   const expandable = props.interactivity.selectedEntity && props.interactivity.selectedEntity.labels !== undefined;
   const [cachedNeighbours, setCachedNeighbours] = React.useState(false);
+  const isShowDetailsValid = expandable && Boolean(props.interactivity.pageIdAndParameterName);
+
   // Clear neighbour cache when selection changes.
   useEffect(() => {
     setCachedNeighbours(false);
@@ -60,6 +63,29 @@ export const GraphChartContextMenu = (props: GraphChartVisualizationProps) => {
               : ''
           }
         />
+
+        {/* Clicking on this redirects to the pageId and sets the global parameter */}
+        {isShowDetailsValid && (
+          <IconMenuItem
+            rightIcon={<InfoOutlinedIcon className='btn-icon-base-r' />}
+            label='Show details'
+            onClick={() => {
+              const { interactivity } = props;
+              const { pageIdAndParameterName, selectedEntity = {} } = interactivity;
+              const title = selectedEntity?.properties?.title || '';
+              // Get pageId, parameterName and nodeType from settings
+              const [pageId, parameterName, nodeType] = pageIdAndParameterName.split(':');
+              interactivity.setContextMenuOpen(false);
+
+              // Only set if the nodeType is valid
+              if (title && selectedEntity?.labels.join(', ') === nodeType) {
+                interactivity?.setPageNumber(pageId);
+                interactivity?.setGlobalParameter(parameterName, selectedEntity?.properties.title);
+              }
+            }}
+          ></IconMenuItem>
+        )}
+
         <IconMenuItem
           rightIcon={<MagnifyingGlassCircleIconOutline className='btn-icon-base-r' />}
           label='Inspect'

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -302,6 +302,21 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: false,
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      pageIdAndParameterName: {
+        label: '<PageId>:<ParameterName>:<NodeType>',
+        type: SELECTION_TYPES.TEXT,
+      },
     },
   },
   bar: {


### PR DESCRIPTION
**Problem**
For my users it is very hard to remember the node label value and select the values from parameter select dropdown.

**Solution**
So we have implemented a show details button on node right click. But you can come up with your own way of implementation for this problem. We tried to use the existing available feature from Neodash.

**Notice:** 
This feature was developed/tested solely for our own use cases, which might differ from yours. Don't have to merge if this is not a value added feature.

**Feature:**
![node redirection](https://github.com/neo4j-labs/neodash/assets/139316519/b1c8e447-cbb5-4b74-b7d9-7f100fc2f323)

```
      {
          "id": "909e565a-1a65-42bc-a730-5b063a3b5723",
          "title": "Movie Names",
          "query": "MATCH (m:Movie) where m.title=$neodash_movie_title_200 return m",
          ....
          "selection": {
            "Movie": "title"
          },
          "settings": {
            "pageIdAndParameterName": "0:neodash_movie_title_100:Movie" // Newly added settings
          },
     }
```
**Caveats:**
The updated global parameter value is not set to the parameter select dropdown if the show details functionality is configured in the same page. But all the graph chart are updating.

