### PR TITLE
Vulcan 235/(Graph report type)Show customised message or render string  response returned from cypher query

### DIFF
--- a/src/component/custom/CustomSingleValueComponent.tsx
+++ b/src/component/custom/CustomSingleValueComponent.tsx
@@ -1,0 +1,13 @@
+import { Box, Typography } from '@mui/material';
+import React from 'react';
+
+/**
+ * A custom component for rendering string result from the cypher query
+ */
+export default function CustomSingleValueComponent({ value = '', sx = {} }) {
+  return (
+    <Box sx={{ width: '100%', marginRight: '15px', marginLeft: '15px' }}>
+      <Typography style={{ ...sx }}>{value}</Typography>
+    </Box>
+  );
+}

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -231,6 +231,24 @@ export const NeoReport = ({
 
   const reportTypes = getReportTypes(extensions);
 
+  /**
+   * This component renders string response from the cypher query. This feature is only applicable for graph report.
+   */
+  if (records !== null && records.length === 1) {
+    if (type === 'graph' && typeof records[0]?._fields[0] === 'string') {
+      return (
+        <CustomSingleValueComponent
+          value={records[0]._fields[0]}
+          sx={{
+            fontSize: settings?.fontSize,
+            color: settings?.color,
+            textAlign: settings?.textAlign,
+          }}
+        />
+      );
+    }
+  }
+
   // Draw the report based on the query status.
   if (disabled) {
     return <div></div>;

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -20,6 +20,7 @@ import { getPrepopulateReportExtension } from '../extensions/state/ExtensionSele
 import { deleteSessionStoragePrepopulationReportFunction } from '../extensions/state/ExtensionActions';
 import { updateFieldsThunk } from '../card/CardThunks';
 import { getDashboardTheme } from '../dashboard/DashboardSelectors';
+import CustomSingleValueComponent from '../component/custom/CustomSingleValueComponent';
 
 const DEFAULT_LOADING_ICON = <LoadingSpinner size='large' className='centered' style={{ marginTop: '-30px' }} />;
 


### PR DESCRIPTION
**Problem:**
The issue which we are trying to address is when user searches for the data which is not exists in our db. The graph report type returns a generic message "Query returned no data" message or an empty canvas. So, to address this we have created custom component which is similar to single value report.

**Solution**
The custom component will check the response of the cypher query. If it return valid node data then it prints the graph or else if it is of type string then the value is printed by the custom component. Please refer the below example cypher query.

`MATCH (n:Movie {title:'SomeRandomMovieOrEmptyString'}) WITH collect(n) as nodes UNWIND (CASE nodes WHEN [] THEN [NULL] ELSE nodes END) AS m RETURN coalesce(m, "No results")`

The result from this query is used and displayed to user. In this way, we could show the users a customized message instead of generic message.

**Screenshots**
![SingleValueComponent](https://github.com/neo4j-labs/neodash/assets/139316519/37b5b634-9e4a-4f92-9243-5982e86f4f8d)

**NOTICE:** 
The program was tested solely for our own use cases, which might differ from yours.

**Author Info**:
Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)

