### PR TITLE
#Vulcan-134/Configurable order of attributes and hide attributes in node and edge detail popup view

### DIFF
--- a/src/chart/graph/GraphChart.tsx
+++ b/src/chart/graph/GraphChart.tsx
@@ -202,6 +202,7 @@ const NeoGraphChart = (props: ChartProps) => {
       clickPosition: clickPosition,
       setClickPosition: setClickPosition,
       createNotification: props.createNotification,
+      customTablePropertiesOfModal: settings.customTablePropertiesOfModal,
     },
     extensions: {
       styleRules: settings.styleRules,

--- a/src/chart/graph/GraphChartVisualization.ts
+++ b/src/chart/graph/GraphChartVisualization.ts
@@ -134,6 +134,7 @@ export interface GraphChartVisualizationProps {
     setClickPosition: (pos) => void;
     setPageNumber: any;
     pageNames: [];
+    customTablePropertiesOfModal: any[]
   };
   /**
    * entries in 'extensions' let users plug in extra functionality into the visualization based on enabled plugins.

--- a/src/chart/graph/component/GraphChartInspectModal.tsx
+++ b/src/chart/graph/component/GraphChartInspectModal.tsx
@@ -8,6 +8,26 @@ import GraphEntityInspectionTable from './GraphEntityInspectionTable';
  * Renders a pop-up window to inspect a node/relationship properties in a read-only table.
  */
 export const NeoGraphChartInspectModal = (props: GraphChartVisualizationProps) => {
+  const selectedEntity = props.interactivity?.selectedEntity;
+
+  const entityName = selectedEntity ? getEntityHeader(props.interactivity.selectedEntity, props.engine.selection) : '';
+
+  const customTablePropertiesOfModal = props.interactivity?.customTablePropertiesOfModal;
+
+  /**
+   * @param properties
+   * @returns custom settings of selected node/edge from settings if specified.
+   */
+  const getSettingsByEntityType = (properties: any[]) =>
+    properties.find((setting) => setting.entityType === entityName);
+
+  /**
+   * check if customTablePropertiesOfModal is an array orelse return empty object.
+   */
+  const customTableDataSettingsForEntityType = Array.isArray(customTablePropertiesOfModal)
+    ? getSettingsByEntityType(customTablePropertiesOfModal)
+    : {};
+
   return (
     <div>
       <Dialog
@@ -22,7 +42,10 @@ export const NeoGraphChartInspectModal = (props: GraphChartVisualizationProps) =
             : ''}
         </Dialog.Header>
         <Dialog.Content>
-          <GraphEntityInspectionTable entity={props.interactivity.selectedEntity}></GraphEntityInspectionTable>
+          <GraphEntityInspectionTable
+            entity={props.interactivity.selectedEntity}
+            customTableDataSettingsForEntityType={customTableDataSettingsForEntityType}
+          ></GraphEntityInspectionTable>
         </Dialog.Content>
       </Dialog>
     </div>

--- a/src/chart/graph/component/GraphEntityInspectionTable.tsx
+++ b/src/chart/graph/component/GraphEntityInspectionTable.tsx
@@ -23,12 +23,51 @@ export const GraphEntityInspectionTable = ({
     console.log('undefined function in GraphEntityInspectionTable');
   },
   checklistEnabled = false,
+  customTableDataSettingsForEntityType,
 }) => {
   const [checkedParameters, setCheckedParameters] = React.useState<string[]>([]);
   const hasPropertyToShow = Object.keys(entity.properties).length > 0;
+  /**
+   * Set keys which needs to be displayed first in defined order
+   */
+  const orderedAttributeList = customTableDataSettingsForEntityType?.ordering || [];
+
+  /**
+   * Set rest of the keys in asc order which should render after the orderedAttributeList
+   */
+  const unorderedAttributeList = Object.keys(entity.properties).filter(
+    (value: string) => !orderedAttributeList.includes(value)
+  );
+
   if (!entity) {
     return <></>;
   }
+
+  const attributesList = (key: any) => (
+    <TableRow key={key}>
+      <TableCell component='th' scope='row'>
+        {key}
+      </TableCell>
+      <TableCell align={'left'}>
+        <ShowMoreText lines={2}>{formatProperty(entity && entity.properties[key].toString())}</ShowMoreText>
+      </TableCell>
+      {checklistEnabled ? (
+        <TableCell align={'center'}>
+          <Checkbox
+            color='default'
+            onChange={(event) => {
+              handleCheckboxClick(key, event.target.checked);
+            }}
+          />
+        </TableCell>
+      ) : (
+        <></>
+      )}
+    </TableRow>
+  );
+
+  const filterCustomDataSettingsForEntityTypeHide = (attr: string) =>
+    !(customTableDataSettingsForEntityType?.hide || []).includes(attr);
 
   /**
    * Function to manage the click
@@ -73,30 +112,17 @@ export const GraphEntityInspectionTable = ({
               </TableCell>
             </TableRow>
           ) : (
-            Object.keys(entity.properties)
-              .sort()
-              .map((key) => (
-                <TableRow key={key}>
-                  <TableCell component='th' scope='row'>
-                    {key}
-                  </TableCell>
-                  <TableCell align={'left'}>
-                    <ShowMoreText lines={2}>{formatProperty(entity && entity.properties[key].toString())}</ShowMoreText>
-                  </TableCell>
-                  {checklistEnabled ? (
-                    <TableCell align={'center'}>
-                      <Checkbox
-                        color='default'
-                        onChange={(event) => {
-                          handleCheckboxClick(key, event.target.checked);
-                        }}
-                      />
-                    </TableCell>
-                  ) : (
-                    <></>
-                  )}
-                </TableRow>
-              ))
+            <>
+              {orderedAttributeList.filter(filterCustomDataSettingsForEntityTypeHide).map((key: string) => {
+                if (entity && entity.properties[key]) {
+                  return attributesList(key);
+                }
+              })}
+              {unorderedAttributeList
+                .filter(filterCustomDataSettingsForEntityTypeHide)
+                .sort()
+                .map((key: string) => attributesList(key))}
+            </>
           )}
         </TableBody>
       </Table>

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -302,6 +302,10 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: false,
       },
+      customTablePropertiesOfModal: {
+        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
+        type: SELECTION_TYPES.DICTIONARY,
+      },
     },
   },
   bar: {


### PR DESCRIPTION
### Ordering and Hide features of graph attributes in detail view

- When user clicks on one node/edge. In the detail popup, Our users wanted few attributes to display in defined order and other attributes which are there will be displayed in ascending order.

![Screenshot 2023-08-30 at 2 25 04 PM](https://github.com/neo4j-labs/neodash/assets/139316519/2b700109-828b-46d8-beaf-39e1a6e2663b)

 ```
{
          "id": "6d00f7c7-4b3d-4b6d-9224-2b61fb0c129a",
          "title": "Movie",
          "query": "MATCH (n)-[e]->(m) RETURN n,e,m LIMIT 20\n\n\n",
          ....
          "settings": {
            "customTablePropertiesOfModal": [
                {
                  "type": "node",
                  "entityType": "Movie",
                  "ordering": ["title", "tagline"],
                  "hide": ["released"]
                }
              ]
          },
          ......
 }
```
- Note: There is no UI to configure this for now. Possible only through JSON upload. What we have done is we introduced one property in settings "customTablePropertiesOfModal". Please refer above.
- The results will look like below image.

![Screenshot 2023-08-30 at 2 40 40 PM](https://github.com/neo4j-labs/neodash/assets/139316519/a46ebe1f-3e04-4762-a69e-cd9e7f672046)

NOTICE:

The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)