### PR TITLE
#Vulcan-224/Execute button and hide query editor for non auto run reports

### DIFF
--- a/src/card/Card.tsx
+++ b/src/card/Card.tsx
@@ -39,6 +39,7 @@ const NeoCard = ({
   extensions, // A set of enabled extensions.
   globalParameters, // Query parameters that are globally set for the entire dashboard.
   dashboardSettings, // Dictionary of settings for the entire dashboard.
+  enableExecuteButtonForIds, // Reports will have save buttons to execute cypher queries
   onRemovePressed, // action to take when the card is removed. (passed from parent)
   onClonePressed, // action to take when user presses the clone button
   onReportHelpButtonPressed, // action to take when someone clicks the 'help' button in the report settings.
@@ -131,6 +132,7 @@ const NeoCard = ({
             settingsOpen={settingsOpen}
             editable={editable}
             dashboardSettings={dashboardSettings}
+            enableExecuteButtonForIds={enableExecuteButtonForIds}
             extensions={extensions}
             settings={report.settings ? report.settings : {}}
             updateReportSetting={(name, value) => onReportSettingUpdate(id, name, value)}

--- a/src/card/view/CardView.tsx
+++ b/src/card/view/CardView.tsx
@@ -2,19 +2,18 @@ import React, { useEffect, useState } from 'react';
 import { ReportItemContainer } from '../CardStyle';
 import NeoCardViewHeader from './CardViewHeader';
 import NeoCardViewFooter from './CardViewFooter';
-import { CardContent, Fab } from '@mui/material';
+import { CardContent, Fab, Stack } from '@mui/material';
 import NeoCodeEditorComponent from '../../component/editor/CodeEditorComponent';
 import { CARD_FOOTER_HEIGHT, CARD_HEADER_HEIGHT } from '../../config/CardConfig';
 import { getReportTypes } from '../../extensions/ExtensionUtils';
 import NeoCodeViewerComponent from '../../component/editor/CodeViewerComponent';
 import { NeoReportWrapper } from '../../report/ReportWrapper';
 import { identifyStyleRuleParameters } from '../../extensions/styling/StyleRuleEvaluator';
-import { IconButton } from '@neo4j-ndl/react';
-import { PlayCircleIconSolid } from '@neo4j-ndl/react/icons';
+import { IconButton, Typography } from '@neo4j-ndl/react';
+import { PlayCircleIconSolid, PlayIconOutline } from '@neo4j-ndl/react/icons';
 import { extensionEnabled } from '../../utils/ReportUtils';
 import { objMerge } from '../../utils/ObjectManipulation';
 import { REPORT_TYPES } from '../../config/ReportConfig';
-import { PlayArrowOutlined } from '@mui/icons-material';
 
 const NeoCardView = ({
   id,
@@ -177,17 +176,23 @@ const NeoCardView = ({
   };
   const executeButton = (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
-      <Fab
-        variant='extended'
-        onClick={() => {
-          setActive(true);
-        }}
-        color='success'
-        size='small'
-      >
-        <PlayArrowOutlined aria-label={'play'} />
-        Execute
-      </Fab>
+      <Stack direction='column' justifyContent='center' alignItems='center' spacing={2}>
+        <IconButton
+          onClick={() => {
+            setActive(true);
+          }}
+          size='large'
+          style={{
+            color: '#ffffff',
+            backgroundColor: 'green',
+          }}
+        >
+          <PlayIconOutline aria-label={'play'} />
+        </IconButton>
+        <Typography variant='body-medium' component='div'>
+          {settings.executeButtonName ?? 'Execute'}
+        </Typography>
+      </Stack>
     </div>
   );
 

--- a/src/card/view/CardView.tsx
+++ b/src/card/view/CardView.tsx
@@ -12,6 +12,8 @@ import { identifyStyleRuleParameters } from '../../extensions/styling/StyleRuleE
 import { IconButton, Typography } from '@neo4j-ndl/react';
 import { PlayCircleIconSolid, PlayIconOutline } from '@neo4j-ndl/react/icons';
 import { extensionEnabled } from '../../utils/ReportUtils';
+import { PlayArrowOutlined } from '@mui/icons-material';
+import { checkParametersNameInGlobalParameter, extractAllParameterNames } from '../../utils/parameterUtils';
 import { objMerge } from '../../utils/ObjectManipulation';
 import { REPORT_TYPES } from '../../config/ReportConfig';
 
@@ -174,10 +176,20 @@ const NeoCardView = ({
       : `${reportHeight}px`,
     overflow: 'auto',
   };
+
+  const isParametersDefined = (cypherQuery: string) => {
+    const parameterNames = extractAllParameterNames(cypherQuery);
+    if (globalParameters) {
+      return checkParametersNameInGlobalParameter(parameterNames, globalParameters);
+    }
+    return false;
+  };
+
   const executeButton = (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <Stack direction='column' justifyContent='center' alignItems='center' spacing={2}>
         <IconButton
+          disabled={isParametersDefined(query)}
           onClick={() => {
             setActive(true);
           }}

--- a/src/card/view/CardView.tsx
+++ b/src/card/view/CardView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { ReportItemContainer } from '../CardStyle';
 import NeoCardViewHeader from './CardViewHeader';
 import NeoCardViewFooter from './CardViewFooter';
-import { CardContent } from '@mui/material';
+import { CardContent, Fab } from '@mui/material';
 import NeoCodeEditorComponent from '../../component/editor/CodeEditorComponent';
 import { CARD_FOOTER_HEIGHT, CARD_HEADER_HEIGHT } from '../../config/CardConfig';
 import { getReportTypes } from '../../extensions/ExtensionUtils';
@@ -14,6 +14,7 @@ import { PlayCircleIconSolid } from '@neo4j-ndl/react/icons';
 import { extensionEnabled } from '../../utils/ReportUtils';
 import { objMerge } from '../../utils/ObjectManipulation';
 import { REPORT_TYPES } from '../../config/ReportConfig';
+import { PlayArrowOutlined } from '@mui/icons-material';
 
 const NeoCardView = ({
   id,
@@ -31,6 +32,7 @@ const NeoCardView = ({
   type,
   selection,
   dashboardSettings,
+  enableExecuteButtonForIds,
   settings,
   updateReportSetting,
   createNotification,
@@ -138,6 +140,11 @@ const NeoCardView = ({
     if (!settingsOpen) {
       setLastRunTimestamp(Date.now());
     }
+
+    // Resets the report with save button
+    if (enableExecuteButtonForIds.map((report) => report.id).includes(id)) {
+      setActive(false);
+    }
   }, [JSON.stringify(localParameters)]);
 
   useEffect(() => {
@@ -168,6 +175,52 @@ const NeoCardView = ({
       : `${reportHeight}px`,
     overflow: 'auto',
   };
+  const executeButton = (
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+      <Fab
+        variant='extended'
+        onClick={() => {
+          setActive(true);
+        }}
+        color='success'
+        size='small'
+      >
+        <PlayArrowOutlined aria-label={'play'} />
+        Execute
+      </Fab>
+    </div>
+  );
+
+  const cypherQueryEditor = (
+    <>
+      <IconButton
+        style={{ float: 'right', marginRight: '9px' }}
+        aria-label='run'
+        onClick={() => {
+          setActive(true);
+        }}
+        clean
+        size='small'
+      >
+        <PlayCircleIconSolid className='n-w-5 n-h-5' aria-label={'play'} />
+      </IconButton>
+      <NeoCodeEditorComponent
+        value={query}
+        language={'cypher'}
+        editable={false}
+        style={{
+          border: '1px solid lightgray',
+          borderRight: '35px solid #eee',
+          marginTop: '0px',
+          marginLeft: '10px',
+          marginRight: '10px',
+        }}
+        onChange={() => {}}
+        placeholder={'No query specified...'}
+      />
+    </>
+  );
+
   const reportContent = (
     <CardContent ref={ref} style={cardContentStyle}>
       {active ? (
@@ -194,33 +247,10 @@ const NeoCardView = ({
           queryTimeLimit={dashboardSettings.queryTimeLimit ? dashboardSettings.queryTimeLimit : 20}
           setFields={onFieldsUpdate}
         />
+      ) : settings.hideQueryEditorInAutoRunOnMode ? (
+        executeButton
       ) : (
-        <>
-          <IconButton
-            style={{ float: 'right', marginRight: '9px' }}
-            aria-label='run'
-            onClick={() => {
-              setActive(true);
-            }}
-            clean
-          >
-            <PlayCircleIconSolid className='n-w-5 n-h-5' aria-label={'play'} />
-          </IconButton>
-          <NeoCodeEditorComponent
-            value={query}
-            language={'cypher'}
-            editable={false}
-            style={{
-              border: '1px solid lightgray',
-              borderRight: '35px solid #eee',
-              marginTop: '0px',
-              marginLeft: '10px',
-              marginRight: '10px',
-            }}
-            onChange={() => {}}
-            placeholder={'No query specified...'}
-          />
-        </>
+        cypherQueryEditor
       )}
     </CardContent>
   );

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -313,6 +313,30 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: false,
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      customTablePropertiesOfModal: {
+        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
+        type: SELECTION_TYPES.DICTIONARY,
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      pageIdAndParameterName: {
+        label: '<PageId>:<ParameterName>:<NodeType>',
+        type: SELECTION_TYPES.TEXT,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
     },
   },
   bar: {
@@ -476,6 +500,22 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
     },
   },
   pie: {
@@ -635,6 +675,22 @@ const _REPORT_TYPES = {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
       },
     },
   },
@@ -813,6 +869,22 @@ const _REPORT_TYPES = {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
       },
     },
   },
@@ -995,6 +1067,11 @@ const _REPORT_TYPES = {
   //       type: SELECTION_TYPES.MULTILINE_TEXT,
   //       default: 'Enter markdown here...',
   //     },
+  // executeButtonName: {
+  //   label: 'Execute Button Name',
+  //   type: SELECTION_TYPES.TEXT,
+  //   default: 'Execute',
+  // },
   //   },
   // },
   map: {
@@ -1099,7 +1176,28 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
-      ...hideQueryEditorInAutoRunOnMode,
+      hideQueryEditorInAutoRunOnMode: {
+        label: 'Hide query editor on auto run on mode',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
     },
   },
   value: {
@@ -1172,6 +1270,22 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
     },
   },
   json: {
@@ -1216,6 +1330,22 @@ const _REPORT_TYPES = {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
       },
     },
   },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -25,6 +25,15 @@ export const RUN_QUERY_DELAY_MS = 300;
 // The default number of rows to process in a visualization.
 export const DEFAULT_ROW_LIMIT = 100;
 
+const hideQueryEditorInAutoRunOnMode = {
+  hideQueryEditorInAutoRunOnMode: {
+    label: 'Hide query editor on auto run on mode',
+    type: SELECTION_TYPES.LIST,
+    values: [true, false],
+    default: false,
+  },
+};
+
 // A dictionary of available reports (visualizations).
 const _REPORT_TYPES = {
   table: {
@@ -87,6 +96,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
@@ -285,6 +295,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       iconStyle: {
         label: 'Node Label images',
         type: SELECTION_TYPES.TEXT,
@@ -459,6 +470,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
@@ -618,6 +630,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
@@ -795,6 +808,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
@@ -970,6 +984,7 @@ const _REPORT_TYPES = {
   //       values: [true, false],
   //       default: true,
   //     },
+  // ...hideQueryEditorInAutoRunOnMode,
   //     refreshRate: {
   //       label: 'Refresh rate (seconds)',
   //       type: SELECTION_TYPES.NUMBER,
@@ -1084,6 +1099,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
     },
   },
   value: {
@@ -1150,6 +1166,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,
@@ -1194,6 +1211,7 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: true,
       },
+      ...hideQueryEditorInAutoRunOnMode,
       refreshRate: {
         label: 'Refresh rate (seconds)',
         type: SELECTION_TYPES.NUMBER,

--- a/src/page/Page.tsx
+++ b/src/page/Page.tsx
@@ -49,6 +49,9 @@ export const NeoPage = ({
   const [lastElement, setLastElement] = React.useState(<div key={getReportKey(pagenumber, '999999')}></div>);
   const [animated, setAnimated] = React.useState(false); // To turn off animations when cards are dragged around.
 
+  // If hideQueryEditorInAutoRunOnMode is true and autorun option is false
+  const enableExecuteButtonForIds = reports.filter((report: any) => report.settings?.hideQueryEditorInAutoRunOnMode);
+
   const availableHandles = () => {
     if (dashboardSettings.resizing && dashboardSettings.resizing == 'all') {
       return ['s', 'w', 'e', 'sw', 'se'];
@@ -199,6 +202,7 @@ export const NeoPage = ({
                 id={id}
                 key={getReportKey(pagenumber, id)}
                 dashboardSettings={dashboardSettings}
+                enableExecuteButtonForIds={enableExecuteButtonForIds}
                 onRemovePressed={onRemovePressed}
                 onClonePressed={(id) => {
                   const { x, y } = getAddCardButtonPosition();

--- a/src/utils/parameterUtils.ts
+++ b/src/utils/parameterUtils.ts
@@ -1,0 +1,22 @@
+export const extractAllParameterNames = (cypherQuery) => {
+    // A regular expression pattern to match parameter names following '$'
+    const pattern = /\$([A-Za-z_]\w*)/g;
+
+    const parameterNames: string[] = [];
+    let match: any;
+
+    while ((match = pattern.exec(cypherQuery)) !== null) {
+        parameterNames.push(match[1]);
+    }
+
+    return parameterNames;
+}
+
+export const checkParametersNameInGlobalParameter = (parameterNames: string[], globalParameterNames: any,) => {
+    for (const key of parameterNames) {
+        if (!globalParameterNames[key] || globalParameterNames[key].trim() === '') {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
Currently, NeoDash fires queries as soon as all input parameters are given. And there is one setting in report "Auto run", But my user wants to execute the cypher query after changing all the parameters. Also my user don't want to display the cypher query to the other users.

So, We have added one more property in the settings "hideQueryEditorInAutoRunOnMode". By enabling this, User will be able to see one execute button whenever there is a change in the parameter.

![execute button optimize](https://github.com/neo4j-labs/neodash/assets/139316519/f12041ce-00bc-4c13-b420-5587856cb927)

**NOTICE** 
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)