### PR TITLE
#653/Fixed the parameter value update issue

### DIFF
--- a/src/chart/parameter/component/NodePropertyParameterSelect.tsx
+++ b/src/chart/parameter/component/NodePropertyParameterSelect.tsx
@@ -46,6 +46,13 @@ const NodePropertyParameterSelectComponent = (props: ParameterSelectProps) => {
 
   const realValueRowIndex = props.compatibilityMode ? 0 : 1 - displayValueRowIndex;
 
+  React.useEffect(() => {
+    setInputDisplayText(props.parameterDisplayValue && multiSelector ? '' : props.parameterDisplayValue);
+    setInputValue(getInitialValue(props.parameterDisplayValue, multiSelector));
+    setParamValueLocal(props.parameterValue);
+    setParamValueDisplayLocal(props.parameterDisplayValue);
+  }, [props.parameterValue, props.parameterDisplayValue]);
+
   const manualHandleParametersUpdate = () => {
     handleParametersUpdate(paramValueLocal, paramValueDisplayLocal, false);
   };


### PR DESCRIPTION
Came across this Parameter Selector Doesn't refresh when a report action sets a parameter #643 bug

We were also facing the same issue. The fix using useEffect, I ensured that the values were set whenever there was a change and ensuring that parameter changes trigger the necessary updates in the NodePropertyParameterSelectComponent only.
![parameterupdate](https://github.com/neo4j-labs/neodash/assets/139316519/c2a73c9c-843a-4564-97d7-c9afa3db1a2c)

**NOTICE**:
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)