### PR TITLE
VULCAN-126/Override default message

### DIFF
--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -97,23 +97,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.MULTILINE_TEXT,
         default: 'Enter markdown here...',
       },
-      expandedCellRenderer: {
-        label: 'Use expanded cell renderer',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      minimizable: {
-        label: 'Minimize Button',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      executeButtonName: {
-        label: 'Execute Button Name',
-        type: SELECTION_TYPES.TEXT,
-        default: 'Execute',
-      },
       overrideDefaultMessage: {
         label: 'Override default message',
         type: SELECTION_TYPES.TEXT,
@@ -332,25 +315,6 @@ const _REPORT_TYPES = {
         label: 'Report Description',
         type: SELECTION_TYPES.MULTILINE_TEXT,
         default: 'Enter markdown here...',
-      },
-      customTablePropertiesOfModal: {
-        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
-        type: SELECTION_TYPES.DICTIONARY,
-      },
-      minimizable: {
-        label: 'Minimize Button',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      pageIdAndParameterName: {
-        label: '<PageId>:<ParameterName>:<NodeType>',
-        type: SELECTION_TYPES.TEXT,
-      },
-      executeButtonName: {
-        label: 'Execute Button Name',
-        type: SELECTION_TYPES.TEXT,
-        default: 'Execute',
       },
       overrideDefaultMessage: {
         label: 'Override default message',

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -92,6 +92,33 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      expandedCellRenderer: {
+        label: 'Use expanded cell renderer',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
+      overrideDefaultMessage: {
+        label: 'Override default message',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Query returned no data.',
+      },
     },
   },
   graph: {
@@ -184,7 +211,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.TEXT,
         default: 'width',
       },
-
       relationshipParticles: {
         label: 'Animated particles on Relationships',
         type: SELECTION_TYPES.LIST,
@@ -301,6 +327,35 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.LIST,
         values: [true, false],
         default: false,
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      customTablePropertiesOfModal: {
+        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
+        type: SELECTION_TYPES.DICTIONARY,
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      pageIdAndParameterName: {
+        label: '<PageId>:<ParameterName>:<NodeType>',
+        type: SELECTION_TYPES.TEXT,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
+      overrideDefaultMessage: {
+        label: 'Override default message',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Query returned no data.',
       },
     },
   },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -92,11 +92,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
-      description: {
-        label: 'Report Description',
-        type: SELECTION_TYPES.MULTILINE_TEXT,
-        default: 'Enter markdown here...',
-      },
       overrideDefaultMessage: {
         label: 'Override default message',
         type: SELECTION_TYPES.TEXT,
@@ -310,11 +305,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.LIST,
         values: [true, false],
         default: false,
-      },
-      description: {
-        label: 'Report Description',
-        type: SELECTION_TYPES.MULTILINE_TEXT,
-        default: 'Enter markdown here...',
       },
       overrideDefaultMessage: {
         label: 'Override default message',

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -250,7 +250,7 @@ export const NeoReport = ({
   } else if (status == QueryStatus.RUNNING) {
     return loadingIcon;
   } else if (status == QueryStatus.NO_DATA) {
-    return <NeoCodeViewerComponent value={'Query returned no data.'} />;
+    return <NeoCodeViewerComponent value={settings?.overrideDefaultMessage || 'Query returned no data.'} />;
   } else if (status == QueryStatus.NO_DRAWABLE_DATA) {
     return <NoDrawableDataErrorMessage />;
   } else if (status == QueryStatus.COMPLETE) {


### PR DESCRIPTION
**Problem and Screenshot:**
As a user I want to show different message to the users if the data is not available for the given query. So we have given an option in the settings to override default message if the query status is NO_DATA. 

![overridedefaultmessage](https://github.com/neo4j-labs/neodash/assets/139316519/9d2f09b9-7ff6-4ae0-a356-9d84eb61ad21)

**Note:** 
For us it is only used for table and graph chart type. So I implemented this feature for the same. You can see if it can be used for other reports as well.

**NOTICE**:
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)