### PR TITLE
VULCAN-126/Override default message

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/reports/graph.adoc
+++ b/docs/modules/ROOT/pages/user-guide/reports/graph.adoc
@@ -127,6 +127,8 @@ that the graph can be explored further. Dynamic Dashboard Parameters
 |Hide Selections |on/off |off |If enabled, hides the property selector
 (footer of the visualization).
 
+|Override no data message |Text |Query returned no data. |Override the message displayed to the user when their query returns no data.
+
 |Auto-run query |on/off |on |when activated automatically runs the query
 when the report is displayed. When set to `off', the query is displayed
 and will need to be executed manually.

--- a/docs/modules/ROOT/pages/user-guide/reports/table.adoc
+++ b/docs/modules/ROOT/pages/user-guide/reports/table.adoc
@@ -54,6 +54,8 @@ set to ``[2, 1, 1]''.
 the bottom right of the table footer. This button lets the user download
 the complete set of table results (all pages) as a CSV file.
 
+|Override no data message |Text |Query returned no data. |Override the message displayed to the user when their query returns no data.
+
 |Auto-run query |on/off |on |when activated automatically runs the query
 when the report is displayed. When set to `off', the query is displayed
 and will need to be executed manually.

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -97,23 +97,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.MULTILINE_TEXT,
         default: 'Enter markdown here...',
       },
-      expandedCellRenderer: {
-        label: 'Use expanded cell renderer',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      minimizable: {
-        label: 'Minimize Button',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      executeButtonName: {
-        label: 'Execute Button Name',
-        type: SELECTION_TYPES.TEXT,
-        default: 'Execute',
-      },
       overrideDefaultMessage: {
         label: 'Override default message',
         type: SELECTION_TYPES.TEXT,
@@ -332,25 +315,6 @@ const _REPORT_TYPES = {
         label: 'Report Description',
         type: SELECTION_TYPES.MULTILINE_TEXT,
         default: 'Enter markdown here...',
-      },
-      customTablePropertiesOfModal: {
-        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
-        type: SELECTION_TYPES.DICTIONARY,
-      },
-      minimizable: {
-        label: 'Minimize Button',
-        type: SELECTION_TYPES.LIST,
-        values: [true, false],
-        default: false,
-      },
-      pageIdAndParameterName: {
-        label: '<PageId>:<ParameterName>:<NodeType>',
-        type: SELECTION_TYPES.TEXT,
-      },
-      executeButtonName: {
-        label: 'Execute Button Name',
-        type: SELECTION_TYPES.TEXT,
-        default: 'Execute',
       },
       overrideDefaultMessage: {
         label: 'Override default message',

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -92,8 +92,8 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
-      overrideDefaultMessage: {
-        label: 'Override default message',
+      noDataMessage: {
+        label: 'Override no data message',
         type: SELECTION_TYPES.TEXT,
         default: 'Query returned no data.',
       },
@@ -306,8 +306,8 @@ const _REPORT_TYPES = {
         values: [true, false],
         default: false,
       },
-      overrideDefaultMessage: {
-        label: 'Override default message',
+      noDataMessage: {
+        label: 'Override no data message',
         type: SELECTION_TYPES.TEXT,
         default: 'Query returned no data.',
       },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -92,6 +92,33 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      expandedCellRenderer: {
+        label: 'Use expanded cell renderer',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
+      overrideDefaultMessage: {
+        label: 'Override default message',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Query returned no data.',
+      },
     },
   },
   graph: {
@@ -184,7 +211,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.TEXT,
         default: 'width',
       },
-
       relationshipParticles: {
         label: 'Animated particles on Relationships',
         type: SELECTION_TYPES.LIST,
@@ -301,6 +327,35 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.LIST,
         values: [true, false],
         default: false,
+      },
+      description: {
+        label: 'Report Description',
+        type: SELECTION_TYPES.MULTILINE_TEXT,
+        default: 'Enter markdown here...',
+      },
+      customTablePropertiesOfModal: {
+        label: 'Customized Ordering and Hide Features Of Attributes In Detailed Modal',
+        type: SELECTION_TYPES.DICTIONARY,
+      },
+      minimizable: {
+        label: 'Minimize Button',
+        type: SELECTION_TYPES.LIST,
+        values: [true, false],
+        default: false,
+      },
+      pageIdAndParameterName: {
+        label: '<PageId>:<ParameterName>:<NodeType>',
+        type: SELECTION_TYPES.TEXT,
+      },
+      executeButtonName: {
+        label: 'Execute Button Name',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Execute',
+      },
+      overrideDefaultMessage: {
+        label: 'Override default message',
+        type: SELECTION_TYPES.TEXT,
+        default: 'Query returned no data.',
       },
     },
   },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -92,11 +92,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.NUMBER,
         default: '0 (No refresh)',
       },
-      description: {
-        label: 'Report Description',
-        type: SELECTION_TYPES.MULTILINE_TEXT,
-        default: 'Enter markdown here...',
-      },
       overrideDefaultMessage: {
         label: 'Override default message',
         type: SELECTION_TYPES.TEXT,
@@ -310,11 +305,6 @@ const _REPORT_TYPES = {
         type: SELECTION_TYPES.LIST,
         values: [true, false],
         default: false,
-      },
-      description: {
-        label: 'Report Description',
-        type: SELECTION_TYPES.MULTILINE_TEXT,
-        default: 'Enter markdown here...',
       },
       overrideDefaultMessage: {
         label: 'Override default message',

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -250,7 +250,7 @@ export const NeoReport = ({
   } else if (status == QueryStatus.RUNNING) {
     return loadingIcon;
   } else if (status == QueryStatus.NO_DATA) {
-    return <NeoCodeViewerComponent value={settings?.overrideDefaultMessage || 'Query returned no data.'} />;
+    return <NeoCodeViewerComponent value={settings?.noDataMessage || 'Query returned no data.'} />;
   } else if (status == QueryStatus.NO_DRAWABLE_DATA) {
     return <NoDrawableDataErrorMessage />;
   } else if (status == QueryStatus.COMPLETE) {

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -250,7 +250,7 @@ export const NeoReport = ({
   } else if (status == QueryStatus.RUNNING) {
     return loadingIcon;
   } else if (status == QueryStatus.NO_DATA) {
-    return <NeoCodeViewerComponent value={'Query returned no data.'} />;
+    return <NeoCodeViewerComponent value={settings?.overrideDefaultMessage || 'Query returned no data.'} />;
   } else if (status == QueryStatus.NO_DRAWABLE_DATA) {
     return <NoDrawableDataErrorMessage />;
   } else if (status == QueryStatus.COMPLETE) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,7 +1701,7 @@
     js-yaml "4.1.0"
     nyc "15.1.0"
 
-"@cypress/request@^2.88.10":
+"@cypress/request@2.88.12":
   version "2.88.12"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
   integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
@@ -2506,25 +2506,25 @@
     "@babel/runtime" "^7.20.13"
     "@neo4j-cypher/codemirror" "1.0.2"
 
-"@neo4j-ndl/base@1.10.1", "@neo4j-ndl/base@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@neo4j-ndl/base/-/base-1.10.1.tgz#18b3b35b9a52d0f5f0ee978c435bc96717ff16a9"
-  integrity sha512-ytz82vN1qMDCZButP4Wm0bLTStz6BWXWWRXMY0iP2Wfw/OAcI3WF2fBVL902FtzCBq0MR/GHHwjgMVpy9g7XeA==
+"@neo4j-ndl/base@1.10.3", "@neo4j-ndl/base@^1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@neo4j-ndl/base/-/base-1.10.3.tgz#99557e3bede274510fc465a781d2e52e0cca47ea"
+  integrity sha512-NTFUz8j9+yx9AN1/TR3yzs7Nt/K+p1yqo2RHqf3UCtuD4ZyMUgYW1gmPQS0Du2S43gvQJkpVenXYJFgjNcFEMA==
 
-"@neo4j-ndl/react@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@neo4j-ndl/react/-/react-1.10.2.tgz#aaf61a06f3c63212f275b2a67ecf588a03287c84"
-  integrity sha512-t4OPV+qA5EqO4qb3FQBfdNnEZAhIO4CiW1qKN4cPeOvXCAyquPBkSM2+8l/rI1+Ra8o4r5FJ1LKln1BhLQPHPw==
+"@neo4j-ndl/react@1.10.8":
+  version "1.10.8"
+  resolved "https://registry.yarnpkg.com/@neo4j-ndl/react/-/react-1.10.8.tgz#ab2ad2719cbdbe8a286ec54b18afc8fae6e5da33"
+  integrity sha512-EVUjwyxup/uNFItJl634z4JA9EVKJ5rvdncu9FOWHs85cw3VNqIfnFuApuuslveo7AknAwkCyeqQmOtjlPVSRQ==
   dependencies:
     "@floating-ui/react" "^0.24.2"
     "@heroicons/react" "2.0.13"
     "@neo4j-cypher/react-codemirror" "^1.0.1"
-    "@neo4j-ndl/base" "^1.10.1"
+    "@neo4j-ndl/base" "^1.10.3"
     "@tanstack/react-table" "^8.9.3"
     classnames "^2.3.1"
     date-fns "^2.30.0"
     detect-browser "^5.3.0"
-    re-resizable "^6.9.9"
+    re-resizable "^6.9.11"
     react-aria "^3.25.0"
     react-datepicker "^4.14.1"
     react-dropzone "^14.0.0"
@@ -4535,10 +4535,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
   integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
 
-"@types/node@^14.14.31":
-  version "14.18.54"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.54.tgz#fc304bd66419030141fa997dc5a9e0e374029ae8"
-  integrity sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==
+"@types/node@^16.18.39":
+  version "16.18.61"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.61.tgz#5ea47e3018348bf3bbbe646b396ba5e720310be1"
+  integrity sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -5924,10 +5924,10 @@ commander@^4.0.0, commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^9.4.1:
   version "9.5.0"
@@ -6194,14 +6194,14 @@ csstype@^3.1.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-cypress@^10.11.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.11.0.tgz#e9fbdd7638bae3d8fb7619fd75a6330d11ebb4e8"
-  integrity sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==
+cypress@^12.17.4:
+  version "12.17.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.4.tgz#b4dadf41673058493fa0d2362faa3da1f6ae2e6c"
+  integrity sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "2.88.12"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
+    "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
@@ -6213,10 +6213,10 @@ cypress@^10.11.0:
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
@@ -6231,12 +6231,13 @@ cypress@^10.11.0:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -10175,7 +10176,7 @@ minimatch@^7.4.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -11269,6 +11270,11 @@ process-utils@^4.0.0:
     memoizee "^0.4.14"
     type "^2.1.0"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -11389,10 +11395,10 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-re-resizable@^6.9.9:
-  version "6.9.9"
-  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.9.tgz#99e8b31c67a62115dc9c5394b7e55892265be216"
-  integrity sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==
+re-resizable@^6.9.11:
+  version "6.9.11"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.11.tgz#f356e27877f12d926d076ab9ad9ff0b95912b475"
+  integrity sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==
 
 react-aria@^3.25.0:
   version "3.25.0"
@@ -12210,7 +12216,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.7, semver@^7.3.8:
+semver@^7.3.7, semver@^7.3.8, semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
Problem and Screenshot:
As a user I want to show different message to the users if the data is not available for the given query. So we have given an option in the settings to override default message if the query status is NO_DATA.
![image](https://github.com/neo4j-labs/neodash/assets/1754968/3cc18563-2ce1-49ef-8506-fcf3c9925681)

overridedefaultmessage

Note:
For us it is only used for table and graph chart type. So I implemented this feature for the same. You can see if it can be used for other reports as well.

NOTICE:
The program was tested solely for our own use cases, which might differ from yours.
Author Info: Monish [monish.nandakumaran@mercedes-benz.com](mailto:monish.nandakumaran@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)