### PR TITLE
adding in advanced config for the graph viz more graph layout config …

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/reports/graph.adoc
+++ b/docs/modules/ROOT/pages/user-guide/reports/graph.adoc
@@ -97,10 +97,13 @@ If 0, no arrow will be drawn.
 |Background Color |Text |#fafafa |The background color of the
 visualization.
 
-|Layout (experimental) |List |force-directed |Use this to switch from
-the main (force-directed) layout to one of the two experimental layouts
-(tree/radial). For the experimental layouts, make sure your graph is a
-DAG (directed acyclic graph).
+|Layout (experimental) |List |force-directed |tree-top-down |tree-bottom-up |tree-left-right |tree-right-left |radial | Use this to switch from
+the main (force-directed) layout to one of the experimental layouts
+(tree, radial). For the experimental layouts, make sure
+your graph is a DAG (directed acyclic graph).
+
+| Graph Depth Separation | Number | 30 | Specify the level distance for the tree layout. 
+This setting controls the separation between different levels in the tree hierarchy. Adjusting this value impacts the overall spacing of the tree layout in your graph visualization.
 
 |Enable graph exploration |on/off |on |Enables basic exploration functionality for the graph. Exploration can be done by right clicking on a node, and choosing 'Expand' to choose a type to traverse. Data is retrieved real-time and not cached in the visualization.
 

--- a/src/chart/graph/GraphChart.tsx
+++ b/src/chart/graph/GraphChart.tsx
@@ -162,6 +162,7 @@ const NeoGraphChart = (props: ChartProps) => {
     },
     engine: {
       layout: layouts[settings.layout],
+      graphDepthSep: settings.graphDepthSep,
       queryCallback: props.queryCallback,
       cooldownTicks: cooldownTicks,
       setCooldownTicks: setCooldownTicks,

--- a/src/chart/graph/GraphChartVisualization.ts
+++ b/src/chart/graph/GraphChartVisualization.ts
@@ -3,7 +3,10 @@
  */
 export const layouts = {
   'force-directed': undefined,
-  tree: 'td',
+  'tree-top-down': 'td',
+  'tree-bottom-up': 'bu',
+  'tree-left-right': 'lr',
+  'tree-right-left': 'rl',
   radial: 'radialout',
 };
 
@@ -90,6 +93,7 @@ export interface GraphChartVisualizationProps {
    */
   engine: {
     layout: Layout;
+    graphDepthSep: number;
     queryCallback: (query: string, parameters: Record<string, any>, setRecords: any) => void;
     cooldownTicks: number;
     setCooldownTicks: (ticks: number) => void;
@@ -134,6 +138,8 @@ export interface GraphChartVisualizationProps {
     setClickPosition: (pos) => void;
     setPageNumber: any;
     pageNames: [];
+    customTablePropertiesOfModal: any[];
+    pageIdAndParameterName: string;
   };
   /**
    * entries in 'extensions' let users plug in extra functionality into the visualization based on enabled plugins.

--- a/src/chart/graph/GraphChartVisualization2D.tsx
+++ b/src/chart/graph/GraphChartVisualization2D.tsx
@@ -29,6 +29,7 @@ export const NeoGraphChartVisualization2D = (props: GraphChartVisualizationProps
       linkDirectionalArrowLength={props.style.linkDirectionalArrowLength}
       linkDirectionalArrowRelPos={1}
       dagMode={props.engine.layout}
+      dagLevelDistance={props.engine.graphDepthSep}
       linkWidth={(link: any) => link.width}
       linkLabel={(link: any) => (props.interactivity.showPropertiesOnHover ? `<div>${getTooltip(link)}</div>` : '')}
       nodeLabel={(node: any) => (props.interactivity.showPropertiesOnHover ? `<div>${getTooltip(node)}</div>` : '')}

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -212,7 +212,7 @@ const _REPORT_TYPES = {
         default: 'force-directed',
       },
       graphDepthSep: {
-        label: 'Graph Depth Separation (experimental)',
+        label: 'Tree layout level distance',
         type: SELECTION_TYPES.NUMBER,
         default: '30',
       },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -208,8 +208,13 @@ const _REPORT_TYPES = {
       layout: {
         label: 'Graph Layout (experimental)',
         type: SELECTION_TYPES.LIST,
-        values: ['force-directed', 'tree', 'radial'],
+        values: ['force-directed', 'tree-top-down', 'tree-bottom-up', 'tree-left-right', 'tree-right-left', 'radial'],
         default: 'force-directed',
+      },
+      graphDepthSep: {
+        label: 'Graph Depth Separation (experimental)',
+        type: SELECTION_TYPES.NUMBER,
+        default: '30',
       },
       enableExploration: {
         label: 'Enable graph exploration',


### PR DESCRIPTION
…on to control the separation between various levels of a tree heirarchy (DagLevelDistance)

The challenge our internal users are facing is - while they would like to use the new "tree" feature instead of a force-directed graph for certain reports, there are little customization options of the resulting tree. ForceGraph2D has options to control both the orientation of the tree and the distance between different levels of the tree. These two options have been brought in with this PR. The need is a justified one since many graphs are actually shown best in left-right view or bottom-up view (or even right-left view). Also, sometimes the distance between various levels of tree needs to be controlled to ensure information is displayed correctly.

While the UI does get a bit cluttered - both the features added are required by my end users so I thought i'd make a PR for the same.

**NOTICE:** 
The program was tested solely for our own use cases, which might differ from yours.

Author Info:
Brahm Prakash Mishra [brahm.praksh_mishra@mercedes-benz.com](mailto:brahm.praksh_mishra@mercedes-benz.com) on behalf of Mercedes-Benz Research and Development India
[https://github.com/mercedes-benz/mercedes-benz-foss/blob/master/PROVIDER_INFORMATION.md](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)