### PR TITLE
Refactor missing union type code smells

### DIFF
--- a/src/chart/parameter/ParameterSelectCardSettings.tsx
+++ b/src/chart/parameter/ParameterSelectCardSettings.tsx
@@ -9,6 +9,8 @@ import NeoField from '../../component/field/Field';
 import { Dropdown } from '@neo4j-ndl/react';
 import NeoCodeEditorComponent from '../../component/editor/CodeEditorComponent';
 
+type ParameterId = string | undefined | null;
+
 const ParameterSelectCardSettings = ({ query, database, settings, onReportSettingUpdate, onQueryUpdate }) => {
   const { driver } = useContext<Neo4jContextState>(Neo4jContext);
   if (!driver) {
@@ -42,7 +44,7 @@ const ParameterSelectCardSettings = ({ query, database, settings, onReportSettin
   }, [database]);
 
   const cleanParameter = (parameter: string) => parameter.replaceAll(' ', '_').replaceAll('-', '_').toLowerCase();
-  const formatParameterId = (id: string | undefined | null) => {
+  const formatParameterId = (id: ParameterId) => {
     const cleanedId = id ?? '';
     return cleanedId == '' || cleanedId.startsWith('_') ? cleanedId : `_${cleanedId}`;
   };

--- a/src/dashboard/header/DashboardHeaderAboutButton.tsx
+++ b/src/dashboard/header/DashboardHeaderAboutButton.tsx
@@ -15,11 +15,13 @@ import { getExampleReports } from '../../extensions/ExtensionUtils';
 import { NeoReportExamplesModal } from '../../modal/ReportExamplesModal';
 import { enterHandler, openTab } from '../../utils/accessibility';
 
+type HelpMenuOpenEvent = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+
 await StyleConfig.getInstance();
 
 export const NeoAboutButton = ({ connection, onAboutModalOpen, extensions }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const handleHelpMenuOpen = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+  const handleHelpMenuOpen = (event: HelpMenuOpenEvent) => {
     setAnchorEl(event.currentTarget);
   };
   const handleHelpMenuClose = () => {

--- a/src/dashboard/header/DashboardHeaderPageTitle.tsx
+++ b/src/dashboard/header/DashboardHeaderPageTitle.tsx
@@ -10,13 +10,15 @@ import { NeoDeletePageModal } from '../../modal/DeletePageModal';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
+type MenuEditEvent = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+
 export const DashboardHeaderPageTitle = ({ title, tabIndex, removePage, setPageTitle, disabled = false }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const menuOpen = Boolean(anchorEl);
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
   const [editing, setEditing] = React.useState(false);
 
-  const handleMenuEditClick = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+  const handleMenuEditClick = (event: MenuEditEvent) => {
     event.preventDefault();
     if (editing) {
       debouncedSetPageTitle(tabIndex, titleText);

--- a/src/dashboard/header/DashboardTitle.tsx
+++ b/src/dashboard/header/DashboardTitle.tsx
@@ -18,6 +18,8 @@ import NeoDashboardSidebarExportModal from '../sidebar/modal/DashboardSidebarExp
 import NeoExportModal from '../../modal/ExportModal';
 import { setDraft } from '../../application/ApplicationActions';
 
+type SettingsMenuOpenEvent = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+
 export const NeoDashboardTitle = ({
   dashboardTitle,
   setDashboardTitle,
@@ -33,7 +35,7 @@ export const NeoDashboardTitle = ({
   const [editing, setEditing] = React.useState(false);
   const debouncedDashboardTitleUpdate = useCallback(debounce(setDashboardTitle, 250), []);
 
-  const handleSettingsMenuOpen = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+  const handleSettingsMenuOpen = (event: SettingsMenuOpenEvent) => {
     setAnchorEl(event.currentTarget);
   };
   const handleSettingsMenuClose = () => {

--- a/src/extensions/advancedcharts/chart/gantt/frappe/GanttVisualization.tsx
+++ b/src/extensions/advancedcharts/chart/gantt/frappe/GanttVisualization.tsx
@@ -6,6 +6,8 @@ import React, { Component } from 'react';
 import Gantt from './lib';
 import { createUUID } from '../../../../../utils/uuid';
 
+type GantRef = SVGSVGElement | undefined;
+
 const TASK_PADDING = 9;
 const HEADER_HEIGHT = 50;
 const STEP_SIZE = 8;
@@ -18,7 +20,7 @@ const VIEW_MODE = 'Day';
 export default class ReactGantt extends Component {
   props: any;
 
-  ganttRef: SVGSVGElement | undefined = undefined;
+  ganttRef: GantRef = undefined;
 
   key: any;
 


### PR DESCRIPTION
Hello, I'm taking a software quality course, and as a final assignment, we were instructed to perform code smell refactorings in open source projects. For this issue, I identified the Missing Union Type smell in 5 components.

The Missing Union Type occurs when a union type is used inline, without a proper type alias definition. It's recommended to have a type alias, improving maintainability and reducing possible code repetition.

Code quality metrics were collected with Understand, before and after refactoring, and for this code smell, only the CountLine was affected:

| AvgCyclomatic | CountDeclFunction | Cyclomatic | SumCyclomatic | MaxNesting | CountLine | CountLineComment |
| --- | --- | --- | --- | --- | --- | --- |
| 1,93 | 1933 | 3272 | 9594 | 14 | 57053 | 3413|

This pull request contains my refactoring for this smell.