### PR TITLE
Change on filter tooltip to avoid hide table data (Hotfix for #629)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -128,6 +128,10 @@
   overflow-y: hidden !important;
 }
 
+.MuiDataGrid-panel{
+  translate: 0px -152%;
+}
+
 .MuiCard-root {
   box-shadow: 0 0 #0000,0 0 #0000,var(--tw-shadow) !important;
   box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow) !important;


### PR DESCRIPTION
Table's filter tooltip have been displaced on the top of table instead of over the first filtered result to allow users evaluate the result.

Before:

![image](https://github.com/neo4j-labs/neodash/assets/11914201/bb6ea210-375f-4f40-b56d-dc5433127c09)

After: 

![image](https://github.com/neo4j-labs/neodash/assets/11914201/f415588e-1c7a-47df-b350-bc4a2367be92)


