### PR TITLE
Fixed menu placement for node property selector in form modal

### DIFF
--- a/src/chart/parameter/ParameterSelectCardSettings.tsx
+++ b/src/chart/parameter/ParameterSelectCardSettings.tsx
@@ -211,7 +211,7 @@ const ParameterSelectCardSettings = ({ query, database, settings, onReportSettin
           onChange: (newValue) => newValue && handleParameterTypeUpdate(newValue.value),
           options: parameterSelectTypes.map((option) => ({ label: option, value: option })),
           value: { label: selectedType, value: selectedType },
-          menuPlacement: 'auto',
+          menuPlacement: 'bottom',
           menuPortalTarget: document.querySelector('#overlay'),
         }}
         label='Selection Type'


### PR DESCRIPTION
This is a fix for #700 