### PR TITLE
Fix race condition caused by incorrect date casted from serialized dashboard format

### DIFF
--- a/src/dashboard/DashboardThunks.ts
+++ b/src/dashboard/DashboardThunks.ts
@@ -9,6 +9,7 @@ import { createLogThunk } from '../application/logging/LoggingThunk';
 import { applicationGetConnectionUser, applicationIsStandalone } from '../application/ApplicationSelectors';
 import { applicationGetLoggingSettings } from '../application/logging/LoggingSelectors';
 import { NEODASH_VERSION, VERSION_TO_MIGRATE } from './DashboardReducer';
+import { Date as Neo4jDate } from 'neo4j-driver-core/lib/temporal-types.js';
 
 export const removePageThunk = (number) => (dispatch: any, getState: any) => {
   try {
@@ -100,6 +101,16 @@ export const loadDashboardThunk = (uuid, text) => (dispatch: any, getState: any)
     if (dashboard.version !== NEODASH_VERSION) {
       throw `Invalid dashboard version: ${dashboard.version}. Try restarting the application, or retrieve your cached dashboard using a debug report.`;
     }
+
+    // Cast dashboard parameters from serialized format to correct types
+    Object.keys(dashboard.settings.parameters).forEach((key) => {
+      const value = dashboard.settings.parameters[key];
+
+      // Serialized Date to Neo4jDate
+      if (value && value.year && value.month && value.day) {
+        dashboard.settings.parameters[key] = new Neo4jDate(value.year, value.month, value.day);
+      }
+    });
 
     // Reverse engineer the minimal set of fields from the selection loaded.
     dashboard.pages.forEach((p) => {


### PR DESCRIPTION
Fix: when loading a dashboard cast the javascript object (parsed from JSON) back to a Neo4jDate.