### PR TITLE
Fix - Added standalonePasswordWarningHidden option to config-entrypoint.sh

### DIFF
--- a/scripts/config-entrypoint.sh
+++ b/scripts/config-entrypoint.sh
@@ -21,6 +21,7 @@ echo " \
     \"standaloneLoadFromOtherDatabases\": ${standaloneLoadFromOtherDatabases:=false},  \
     \"standaloneMultiDatabase\": ${standaloneMultiDatabase:=false}, \
     \"standaloneDatabaseList\": \"${standaloneDatabaseList:='neo4j'}\", \
+    \"standalonePasswordWarningHidden\": ${standalonePasswordWarningHidden:=false},  \
     \"loggingMode\": \"${loggingMode:='0'}\",  \
     \"loggingDatabase\": \"${loggingDatabase:='logs'}\",  \
     \"customHeader\": \"${customHeader:=}\"  \


### PR DESCRIPTION
I have added the option to configure **standalonePasswordWarningHidden** property of **config.json** using docker environment variables. Without this is not possible to set this propoerty to True in order to hide the warning message.

Just added this new property to config-entrypoint.sh to set this property in config.json. False by default.


If necessary, I will update the documentation to reflect this new configuration option. Please let me know if this is required.