### PR TITLE
Fixing RBAC feature + parameters

### DIFF
--- a/src/extensions/forms/FormsReportConfig.tsx
+++ b/src/extensions/forms/FormsReportConfig.tsx
@@ -46,7 +46,7 @@ export const FORMS = {
         label: 'Clear parameters after submit',
         type: SELECTION_TYPES.LIST,
         values: [true, false],
-        default: false,
+        default: true,
       },
       hasResetButton: {
         label: 'Has Reset Button',

--- a/src/extensions/forms/chart/NeoForm.tsx
+++ b/src/extensions/forms/chart/NeoForm.tsx
@@ -26,7 +26,7 @@ const NeoForm = (props: ChartProps) => {
   const hasResetButton = settings?.hasResetButton ?? true;
   const hasSubmitButton = settings?.hasSubmitButton ?? true;
   const hasSubmitMessage = settings?.hasSubmitMessage ?? true;
-  const clearParametersAfterSubmit = settings?.clearParametersAfterSubmit ?? false;
+  const clearParametersAfterSubmit = settings?.clearParametersAfterSubmit ?? true;
   const [submitButtonActive, setSubmitButtonActive] = React.useState(true);
   const [status, setStatus] = React.useState(FormStatus.DATA_ENTRY);
   const [formResults, setFormResults] = React.useState([]);

--- a/src/extensions/forms/settings/NeoFormCardSettingsModal.tsx
+++ b/src/extensions/forms/settings/NeoFormCardSettingsModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Button, Dialog } from '@neo4j-ndl/react';
 import ParameterSelectCardSettings from '../../../chart/parameter/ParameterSelectCardSettings';
 import NeoCardSettingsFooter from '../../../card/settings/CardSettingsFooter';
+import { objMerge } from '../../../utils/ObjectManipulation';
 
 const NeoFormCardSettingsModal = ({ open, setOpen, index, formFields, setFormFields, database, extensions }) => {
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = React.useState(false);
@@ -24,15 +25,19 @@ const NeoFormCardSettingsModal = ({ open, setOpen, index, formFields, setFormFie
               query={formFields[index].query}
               type={'select'}
               database={database}
-              settings={formFields[index].settings}
+              settings={objMerge({ inputMode: 'cypher' }, formFields[index].settings)}
               extensions={extensions}
               onReportSettingUpdate={(key, value) => {
                 const newFormFields = [...formFields];
                 newFormFields[index].settings[key] = value;
+                if (key == 'type') {
+                  newFormFields[index].type = value;
+                }
                 setFormFields(newFormFields);
               }}
               onQueryUpdate={(query) => {
                 const newFormFields = [...formFields];
+
                 newFormFields[index].query = query;
                 setFormFields(newFormFields);
               }}

--- a/src/extensions/rbac/RBACManagementMenu.tsx
+++ b/src/extensions/rbac/RBACManagementMenu.tsx
@@ -19,7 +19,7 @@ export const RBACManagementMenu = ({ anchorEl, MenuOpen, handleClose, createNoti
     if (!MenuOpen) {
       return;
     }
-    const query = `SHOW ROLES YIELD role WHERE role <> "PUBLIC" return role`;
+    const query = `SHOW PRIVILEGES YIELD role, action WHERE role <> "PUBLIC" RETURN role, 'dbms_actions' in collect(action)`;
     runCypherQuery(
       driver,
       'system',
@@ -32,7 +32,8 @@ export const RBACManagementMenu = ({ anchorEl, MenuOpen, handleClose, createNoti
           createNotification('Unable to retrieve roles', records[0].error);
           return;
         }
-        setRoles(records.map((record) => record._fields[0]));
+        // Only display roles which are not able to do 'dbms_actions', i.e. they are not admins.
+        setRoles(records.filter((r) => r._fields[1] == false).map((record) => record._fields[0]));
       }
     );
   }, [MenuOpen]);

--- a/src/extensions/rbac/RBACManagementMenu.tsx
+++ b/src/extensions/rbac/RBACManagementMenu.tsx
@@ -72,7 +72,7 @@ export const RBACManagementMenu = ({ anchorEl, MenuOpen, handleClose, createNoti
       </Menu>
 
       <RBACManagementModal
-        open={isModalOpen == true}
+        open={isModalOpen}
         handleClose={() => {
           setIsModalOpen(false);
         }}

--- a/src/extensions/rbac/RBACManagementModal.tsx
+++ b/src/extensions/rbac/RBACManagementModal.tsx
@@ -75,9 +75,9 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
     retrieveLabelsList(driver, selectedOption.value, (records) => parseLabelsList(selectedOption.value, records));
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     createNotification('Updating', `Access for role '${currentRole}' is being updated, please wait...`);
-    updateUsers(
+    await updateUsers(
       driver,
       currentRole,
       neo4jUsers,

--- a/src/extensions/rbac/RBACManagementModal.tsx
+++ b/src/extensions/rbac/RBACManagementModal.tsx
@@ -28,7 +28,6 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
   const [denyList, setDenyList] = useState([]);
   const [fixedAllowList, setFixedAllowList] = useState([]);
   const [fixedDenyList, setFixedDenyList] = useState([]);
-
   const [denyCompleted, setDenyCompleted] = useState(false);
   const [allowCompleted, setAllowCompleted] = useState(false);
   const [usersCompleted, setUsersCompleted] = useState(false);
@@ -42,11 +41,16 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
       setSelectedDatabase('');
       return;
     }
+    setDenyCompleted(false);
+    setAllowCompleted(false);
+    setUsersCompleted(false);
+    setFailed(false);
     retrieveDatabaseList(driver, setDatabases);
     retrieveNeo4jUsers(driver, currentRole, setNeo4jUsers, setSelectedUsers);
   }, [open]);
 
   useEffect(() => {
+    console.log([denyCompleted, allowCompleted, usersCompleted, failed]);
     if (failed !== false) {
       createNotification('Unable to update privileges', `${failed}`);
     } else if (denyCompleted && allowCompleted && usersCompleted) {
@@ -77,7 +81,8 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
 
   const handleSave = async () => {
     createNotification('Updating', `Access for role '${currentRole}' is being updated, please wait...`);
-    await updateUsers(
+    console.log(selectedUsers);
+    updateUsers(
       driver,
       currentRole,
       neo4jUsers,
@@ -85,6 +90,7 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
       () => setUsersCompleted(true),
       (failReason) => setFailed(`Operation 'ROLE-USER ASSIGNMENT' failed.\n Reason: ${failReason}`)
     );
+
     if (selectedDatabase) {
       const nonFixedDenyList = denyList.filter((n) => !fixedDenyList.includes(n));
       const nonFixedAllowList = allowList.filter((n) => !fixedDenyList.includes(n));
@@ -115,7 +121,7 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
       setDenyCompleted(true);
       setAllowCompleted(true);
     }
-
+    console.log([denyCompleted, allowCompleted, usersCompleted, failed]);
     handleClose();
   };
 

--- a/src/extensions/rbac/RBACManagementModal.tsx
+++ b/src/extensions/rbac/RBACManagementModal.tsx
@@ -58,12 +58,21 @@ export const RBACManagementModal = ({ open, handleClose, currentRole, createNoti
     retrieveLabelsList(driver, selectedOption.value, (records) => parseLabelsList(selectedOption.value, records));
   };
 
-  const handleSave = () => {
-    updateUsers(driver, currentRole, neo4jUsers, selectedUsers);
+  const handleSave = async () => {
+    await updateUsers(driver, currentRole, neo4jUsers, selectedUsers);
     if (selectedDatabase) {
       createNotification('Updating', `Access for role '${currentRole}' is being updated, please wait...`);
-      updatePrivileges(driver, selectedDatabase, currentRole, labels, denyList, Operation.DENY, createNotification);
-      updatePrivileges(driver, selectedDatabase, currentRole, labels, allowList, Operation.GRANT, createNotification);
+      updatePrivileges(
+        driver,
+        selectedDatabase,
+        currentRole,
+        labels,
+        denyList,
+        Operation.DENY,
+        createNotification
+      ).then(() =>
+        updatePrivileges(driver, selectedDatabase, currentRole, labels, allowList, Operation.GRANT, createNotification)
+      );
     } else {
       createNotification('Success', `Users have been updated for role '${currentRole}'.`);
     }

--- a/src/modal/ExportModal.tsx
+++ b/src/modal/ExportModal.tsx
@@ -14,7 +14,7 @@ export const NeoExportModal = ({ dashboard }) => {
   return (
     <>
       <Tooltip title='Export' aria-label='export' disableInteractive>
-        <IconButton className='n-mx-1' onClick={() => setOpen(true)} aria-label='Export' title='Export'>
+        <IconButton className='n-mx-1' onClick={() => setOpen(true)} aria-label='Export'>
           <DocumentArrowDownIconOutline />
         </IconButton>
       </Tooltip>

--- a/src/report/ReportQueryRunner.ts
+++ b/src/report/ReportQueryRunner.ts
@@ -65,6 +65,7 @@ export async function runCypherQuery(
     setStatus(QueryStatus.ERROR);
     return;
   }
+  console.log(query);
   const session = database ? driver.session({ database: database }) : driver.session();
   const transaction = session.beginTransaction({ timeout: queryTimeLimit * 1000, connectionTimeout: 2000 });
 


### PR DESCRIPTION
- [x] user should not be able to modify its own grants. Filter out any roles from the role dropdown list that have the dbms_actions privileges.
- [x] handle correct notification for errors, always shows success even if it’s not really happened. 
- [x] remove option to DENY *,.
- [x] remove option to delete cross-db priveleges from the multiselector.
- [x] the deny and the grant function should go in parallel (async and awaiting makes it almost work (sometimes they clash, still not perfectly serial, at the deepest level of the _updatePrivileges_ function, the driver gets stuck when two queries run simultaneously, so i don't think we will need to use the useTimeout for the last query, they just need to run serially (deny) -> (grant))