### PR TITLE
fixes bug where arrays are passed as [object Object]

### DIFF
--- a/src/chart/ChartUtils.ts
+++ b/src/chart/ChartUtils.ts
@@ -218,8 +218,14 @@ export function replaceDashboardParameters(str, parameters) {
     let param = _.replace(`$`, '').trim();
     let val = parameters?.[param] || null;
     let type = getRecordType(val);
-    let valueRender = type === 'string' || type == 'link' ? val : RenderSubValue(val);
-    return valueRender;
+
+    // Arrays weren't playing nicely with RenderSubValue(). Each object would be passed separately and return [oject Object].
+    if (type === 'string' || type == 'link' ) {
+      return val;
+    } else if (type === 'array') {
+      return RenderSubValue(val.join(', '));
+    }
+    return RenderSubValue(val);
   };
 
   let newString = str.replace(rx, parameterElementReplacer).replace(rxSimple, parameterSimpleReplacer);

--- a/src/chart/table/TableChart.tsx
+++ b/src/chart/table/TableChart.tsx
@@ -50,7 +50,7 @@ function renderAsButtonWrapper(renderer) {
         style={{ width: '100%', marginLeft: '5px', marginRight: '5px' }}
         variant='contained'
         color='primary'
-      >{`${outputValue}`}</Button>
+      >{outputValue}</Button>
     );
   };
 }


### PR DESCRIPTION
This PR fixes a bug where passing a list as a report action would cause the output to be [object Object] for each element in that list.

The Cypher query returns the list object ['a', 'few', 'words'] as 'list'.

![Screenshot 2024-04-09 at 11 12 30](https://github.com/neo4j-labs/neodash/assets/134382136/72823768-5413-42c9-8248-ac4144ad5746)

This is what previously happened when turning on a report action and its behaviour in other charts:

![Screenshot 2024-04-09 at 11 16 12](https://github.com/neo4j-labs/neodash/assets/134382136/f2390b93-5861-4eeb-9ff4-35781c0cb83f)

![Screenshot 2024-04-09 at 11 16 31](https://github.com/neo4j-labs/neodash/assets/134382136/13e641c2-52cb-400d-ad5d-99e4ae47068e)

This is the result after the fix:

![Screenshot 2024-04-09 at 11 16 59](https://github.com/neo4j-labs/neodash/assets/134382136/68494117-ef18-4daa-9339-e90e18f655de)