### PR TITLE
Fix padding in compact table with report actions

### DIFF
--- a/src/chart/table/TableChart.tsx
+++ b/src/chart/table/TableChart.tsx
@@ -317,6 +317,7 @@ export const NeoTableChart = (props: ChartProps) => {
           }}
           sx={{
             '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': { py: '3px' },
+            '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell:has(button)': { py: '0px' },
             '&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell': { py: '15px' },
             '&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell': { py: '22px' },
             '&.MuiDataGrid-root .MuiDataGrid-cell': { wordBreak: 'break-word' },


### PR DESCRIPTION
Fixes some padding added to compact table rows when they contain report actions, making said rows not look compact.