### PR TITLE
Fixed issues where cross database dashboard sharing always reverted back to the default database

### DIFF
--- a/src/application/ApplicationActions.ts
+++ b/src/application/ApplicationActions.ts
@@ -178,7 +178,7 @@ export const setStandaloneEnabled = (
 
 export const SET_STANDALONE_MODE = 'APPLICATION/SET_STANDALONE_MODE';
 export const setStandaloneMode = (standalone: boolean) => ({
-  type: SET_STANDALONE_ENABLED,
+  type: SET_STANDALONE_MODE,
   payload: { standalone },
 });
 

--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -259,7 +259,10 @@ export const handleSharedDashboardsThunk = () => (dispatch: any) => {
       const skipConfirmation = urlParams.get('skipConfirmation') == 'Yes';
 
       const dashboardDatabase = urlParams.get('dashboardDatabase');
-      dispatch(setStandaloneDashboardDatabase(dashboardDatabase));
+      if (dashboardDatabase) {
+        dispatch(setStandaloneDashboardDatabase(dashboardDatabase));
+      }
+
       if (urlParams.get('credentials')) {
         setWelcomeScreenOpen(false);
         const connection = decodeURIComponent(urlParams.get('credentials'));
@@ -363,6 +366,8 @@ export const onConfirmLoadSharedDashboardThunk = () => (dispatch: any, getState:
 
     if (shareDetails.dashboardDatabase) {
       dispatch(setStandaloneDashboardDatabase(shareDetails.dashboardDatabase));
+    } else if (!state.application.standaloneDashboardDatabase) {
+      // No standalone dashboard database configured, fall back to default
       dispatch(setStandaloneDashboardDatabase(shareDetails.database));
     }
     if (shareDetails.url) {
@@ -452,6 +457,9 @@ export const loadApplicationConfigThunk = () => async (dispatch: any, getState: 
     dispatch(setSSOProviders(config.ssoProviders));
 
     const { standalone } = config;
+    // if a dashboard database was previously set, remember to use it.
+    const dashboardDatabase = state.application.standaloneDashboardDatabase;
+
     dispatch(
       setStandaloneEnabled(
         standalone,
@@ -460,7 +468,7 @@ export const loadApplicationConfigThunk = () => async (dispatch: any, getState: 
         config.standalonePort,
         config.standaloneDatabase,
         config.standaloneDashboardName,
-        config.standaloneDashboardDatabase,
+        dashboardDatabase ? dashboardDatabase : config.standaloneDashboardDatabase,
         config.standaloneDashboardURL,
         config.standaloneUsername,
         config.standalonePassword,

--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -468,7 +468,7 @@ export const loadApplicationConfigThunk = () => async (dispatch: any, getState: 
         config.standalonePort,
         config.standaloneDatabase,
         config.standaloneDashboardName,
-        dashboardDatabase ? dashboardDatabase : config.standaloneDashboardDatabase,
+        dashboardDatabase || config.standaloneDashboardDatabase,
         config.standaloneDashboardURL,
         config.standaloneUsername,
         config.standalonePassword,


### PR DESCRIPTION
This PR makes sure we are correctly handling share links in all four scenarios where the dashboards database differs from the main "data" database:
- Link with credentials in read-only mode
- Link without credentials in read-only mode
- Link with credentials in editor mode
- Link without credentials in editor mode