### PR TITLE
fixing casting error at while loading the dashboards

### DIFF
--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -14,7 +14,6 @@ import { createNotificationThunk } from '../page/PageThunks';
 import { runCypherQuery } from '../report/ReportQueryRunner';
 import {
   setPageNumberThunk,
-  updateParametersToNeo4jTypeThunk,
   updateGlobalParametersThunk,
   updateSessionParameterThunk,
 } from '../settings/SettingsThunks';
@@ -499,8 +498,6 @@ export const loadApplicationConfigThunk = () => async (dispatch: any, getState: 
         );
       }
     }
-    // At the load of a dashboard, we want to ensure correct casting types
-    dispatch(updateParametersToNeo4jTypeThunk());
 
     // SSO - specific case starts here.
     if (state.application.waitForSSO) {

--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -639,8 +639,8 @@ export const initializeApplicationAsStandaloneThunk =
     } else {
       dispatch(setDashboardToLoadAfterConnecting(`name:${config.standaloneDashboardName}`));
     }
-
     dispatch(setParametersToLoadAfterConnecting(paramsToSetAfterConnecting));
+    dispatch(updateGlobalParametersThunk(paramsToSetAfterConnecting));
 
     if (clearNotificationAfterLoad) {
       dispatch(clearNotification());

--- a/src/chart/ChartUtils.ts
+++ b/src/chart/ChartUtils.ts
@@ -220,7 +220,7 @@ export function replaceDashboardParameters(str, parameters) {
     let type = getRecordType(val);
 
     // Arrays weren't playing nicely with RenderSubValue(). Each object would be passed separately and return [oject Object].
-    if (type === 'string' || type == 'link' ) {
+    if (type === 'string' || type == 'link') {
       return val;
     } else if (type === 'array') {
       return RenderSubValue(val.join(', '));
@@ -415,7 +415,7 @@ export function isCastableToNeo4jDate(value: object) {
     return false;
   }
   let keys = Object.keys(value);
-  return keys.length == 3 && keys.includes('day') && keys.includes('month') && keys.includes('year');
+  return keys.includes('day') && keys.includes('month') && keys.includes('year');
 }
 
 /**
@@ -425,7 +425,7 @@ export function isCastableToNeo4jDate(value: object) {
  */
 export function castToNeo4jDate(value: object) {
   if (isCastableToNeo4jDate(value)) {
-    return new Neo4jDate(value.year, value.month, value.day);
+    return new Neo4jDate(toNumber(value.year), toNumber(value.month), toNumber(value.day));
   }
   throw new Error(`Invalid input for castToNeo4jDate: ${value}`);
 }

--- a/src/dashboard/DashboardThunks.ts
+++ b/src/dashboard/DashboardThunks.ts
@@ -9,7 +9,6 @@ import { createLogThunk } from '../application/logging/LoggingThunk';
 import { applicationGetConnectionUser, applicationIsStandalone } from '../application/ApplicationSelectors';
 import { applicationGetLoggingSettings } from '../application/logging/LoggingSelectors';
 import { NEODASH_VERSION, VERSION_TO_MIGRATE } from './DashboardReducer';
-import { Date as Neo4jDate } from 'neo4j-driver-core/lib/temporal-types.js';
 
 export const removePageThunk = (number) => (dispatch: any, getState: any) => {
   try {
@@ -113,16 +112,6 @@ export const loadDashboardThunk = (uuid, text) => (dispatch: any, getState: any)
       throw `Invalid dashboard version: ${dashboard.version}. Try restarting the application, or retrieve your cached dashboard using a debug report.`;
     }
 
-    // Cast dashboard parameters from serialized format to correct types
-    Object.keys(dashboard.settings.parameters).forEach((key) => {
-      const value = dashboard.settings.parameters[key];
-
-      // Serialized Date to Neo4jDate
-      if (value && value.year && value.month && value.day) {
-        dashboard.settings.parameters[key] = new Neo4jDate(value.year, value.month, value.day);
-      }
-    });
-
     // Reverse engineer the minimal set of fields from the selection loaded.
     dashboard.pages.forEach((p) => {
       p.reports.forEach((r) => {
@@ -140,8 +129,8 @@ export const loadDashboardThunk = (uuid, text) => (dispatch: any, getState: any)
     const { application } = getState();
 
     dispatch(updateGlobalParametersThunk(application.parametersToLoadAfterConnecting));
+    dispatch(updateGlobalParametersThunk(dashboard.settings.parameters));
     dispatch(setParametersToLoadAfterConnecting(null));
-
     // Pre-2.3.4 dashboards might now always have a UUID. Set it if not present.
     if (!dashboard.uuid) {
       dispatch(setDashboardUuid(uuid));

--- a/src/dashboard/DashboardThunks.ts
+++ b/src/dashboard/DashboardThunks.ts
@@ -3,7 +3,7 @@ import { updateDashboardSetting } from '../settings/SettingsActions';
 import { addPage, movePage, removePage, resetDashboardState, setDashboard, setDashboardUuid } from './DashboardActions';
 import { QueryStatus, runCypherQuery } from '../report/ReportQueryRunner';
 import { setDraft, setParametersToLoadAfterConnecting, setWelcomeScreenOpen } from '../application/ApplicationActions';
-import { updateGlobalParametersThunk, updateParametersToNeo4jTypeThunk } from '../settings/SettingsThunks';
+import { updateGlobalParametersThunk } from '../settings/SettingsThunks';
 import { createUUID } from '../utils/uuid';
 import { createLogThunk } from '../application/logging/LoggingThunk';
 import { applicationGetConnectionUser, applicationIsStandalone } from '../application/ApplicationSelectors';
@@ -141,7 +141,6 @@ export const loadDashboardThunk = (uuid, text) => (dispatch: any, getState: any)
 
     dispatch(updateGlobalParametersThunk(application.parametersToLoadAfterConnecting));
     dispatch(setParametersToLoadAfterConnecting(null));
-    dispatch(updateParametersToNeo4jTypeThunk());
 
     // Pre-2.3.4 dashboards might now always have a UUID. Set it if not present.
     if (!dashboard.uuid) {

--- a/src/extensions/advancedcharts/Utils.ts
+++ b/src/extensions/advancedcharts/Utils.ts
@@ -1,7 +1,6 @@
 import { valueIsArray } from '../../chart/ChartUtils';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { getPageNumbersAndNames } from '../../dashboard/DashboardSelectors';
-import { updateDashboardSetting } from '../../settings/SettingsActions';
 
 export const getRule = (e, rules, type) => {
   let r = getRuleWithFieldPropertyName(e, rules, type, null);

--- a/src/settings/SettingsThunks.ts
+++ b/src/settings/SettingsThunks.ts
@@ -1,6 +1,6 @@
 import { setSessionParameters } from '../application/ApplicationActions';
 import { hardResetCardSettings } from '../card/CardActions';
-import { castToNeo4jDate, isCastableToNeo4jDate, valueIsNode } from '../chart/ChartUtils';
+import { castToNeo4jDate, isCastableToNeo4jDate, toNumber, valueIsNode } from '../chart/ChartUtils';
 import { createNotificationThunk } from '../page/PageThunks';
 import { updateDashboardSetting } from './SettingsActions';
 
@@ -73,6 +73,7 @@ export const updateGlobalParametersThunk = (newParameters) => (dispatch: any, ge
         }
       });
       dispatch(updateDashboardSetting('parameters', { ...parameters }));
+      dispatch(updateParametersToNeo4jTypeThunk());
     }
   } catch (e) {
     dispatch(createNotificationThunk('Unable to update global parameters', e));
@@ -86,12 +87,13 @@ export const updateParametersToNeo4jTypeThunk = () => (dispatch: any, getState: 
   try {
     const { settings } = getState().dashboard;
     const parameters = settings.parameters ? settings.parameters : {};
-
     // if new parameters are set...
     // iterate over the key value pairs in parameters
     Object.keys(parameters).forEach((key) => {
       if (isCastableToNeo4jDate(parameters[key])) {
         parameters[key] = castToNeo4jDate(parameters[key]);
+      } else if (parameters[key] && typeof toNumber(parameters[key]) === 'number') {
+        parameters[key] = toNumber(parameters[key]);
       } else if (parameters[key] == undefined) {
         delete parameters[key];
       }


### PR DESCRIPTION
When loading a dashboard, the parameters were always kept in the same format as the one stored in the state (EX: numbers with high,low should be casted to number)