### PR TITLE
Added release notes for 2.4.6

### DIFF
--- a/.github/workflows/master-deployment.yml
+++ b/.github/workflows/master-deployment.yml
@@ -79,7 +79,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:2.4.5
+          tags: ${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_LABS_USERNAME }}/neodash:2.4.6
   build-docker-legacy:
     needs: build-test
     runs-on: neodash-runners
@@ -103,7 +103,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_USERNAME }}/neodash:2.4.5
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/neodash:latest,${{ secrets.DOCKER_HUB_USERNAME }}/neodash:2.4.6
   deploy-gallery:
     runs-on: neodash-runners
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ USER nginx
 EXPOSE $NGINX_PORT
 
 HEALTHCHECK cmd curl --fail "http://localhost:$NGINX_PORT" || exit 1
-LABEL version="2.4.5"
+LABEL version="2.4.6"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## NeoDash 2.4.6
+This is a minor release containing a few critical fixes and some extra style customizations:
+
+- Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
+- Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
+- Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
+- fixing casting error of number values while loading dashboards ([874](https://github.com/neo4j-labs/neodash/pull/874)).
+- Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)). 
+
 ## NeoDash 2.4.5
 This is a small release containing a few fixes:
 - Fixed rendering of string arrays inside tables, report titles, and report action buttons [849](https://github.com/neo4j-labs/neodash/pull/849)

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,6 @@ This is a minor release containing a few critical fixes and some extra style cus
 - Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
 - Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
 - Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
-- fixing casting error of number values while loading dashboards ([874](https://github.com/neo4j-labs/neodash/pull/874)).
 - Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)). 
 
 ## NeoDash 2.4.5

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 This is a minor release containing a few critical fixes and some extra style customizations:
 
 - Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
-- Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
+- Make wrapping in table optional, disabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
 - Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
 - Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)). 
 

--- a/docs/modules/ROOT/pages/developer-guide/deploy-a-build.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/deploy-a-build.adoc
@@ -37,7 +37,7 @@ Depending on the webserver type and version, this could be different directory.
 As an example - to copy the files to an nginx webserver using `scp`:
 
 ```bash
-scp neodash-2.4.5 username@host:/usr/share/nginx/html
+scp neodash-2.4.6 username@host:/usr/share/nginx/html
 ```
 
 NeoDash should now be visible by visiting your (sub)domain in the browser.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neodash",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "NeoDash - Neo4j Dashboard Builder",
   "neo4jDesktop": {
     "apiVersion": "^1.2.0"

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,5 +4,4 @@ This is a minor release containing a few critical fixes and some extra style cus
 - Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
 - Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
 - Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
-- fixing casting error of number values while loading dashboards ([874](https://github.com/neo4j-labs/neodash/pull/874)).
 - Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)).

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,11 +1,8 @@
-## NeoDash 2.4.5
-This is a small release containing a few fixes:
-- Fixed rendering of string arrays inside tables, report titles, and report action buttons [849](https://github.com/neo4j-labs/neodash/pull/849)
-- Allowed text to wrap in tables, preserving the number of rows [852](https://github.com/neo4j-labs/neodash/pull/852)
-- Disabled auto-sorting of Cypher query-based Parameter Select ; use Cypher ORDER BY to control result order [857](https://github.com/neo4j-labs/neodash/pull/857)
-- Updated role selector menu, and made user updates more robust [854](https://github.com/neo4j-labs/neodash/pull/854)
+## NeoDash 2.4.6
+This is a minor release containing a few critical fixes and some extra style customizations:
 
-Thanks to all the contributors for this release: 
-- [MariusC](https://github.com/mariusconjeaud),
-- [LiamEdwardsLamarche](https://github.com/LiamEdwardsLamarche),
-- [AleSim94](https://github.com/AleSim94)
+- Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
+- Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
+- Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
+- fixing casting error of number values while loading dashboards ([874](https://github.com/neo4j-labs/neodash/pull/874)).
+- Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)).

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,6 @@
 This is a minor release containing a few critical fixes and some extra style customizations:
 
 - Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
-- Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
+- Make wrapping in table optional, disabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
 - Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
 - Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)).

--- a/src/modal/AboutModal.tsx
+++ b/src/modal/AboutModal.tsx
@@ -3,7 +3,7 @@ import { Button, Dialog, TextLink } from '@neo4j-ndl/react';
 import { BookOpenIconOutline, BeakerIconOutline } from '@neo4j-ndl/react/icons';
 import { Section, SectionTitle, SectionContent } from './ModalUtils';
 
-export const version = '2.4.5';
+export const version = '2.4.6';
 
 export const NeoAboutModal = ({ open, handleClose, getDebugState }) => {
   const downloadDebugFile = () => {


### PR DESCRIPTION
## NeoDash 2.4.6
This is a minor release containing a few critical fixes and some extra style customizations:

- Fix bad text wrapping for arrays in tables ([868](https://github.com/neo4j-labs/neodash/pull/868)).
- Make wrapping in table optional, enabled by default ([872](https://github.com/neo4j-labs/neodash/pull/872)).
- Fixed issues where cross database dashboard sharing always reverted back to the default database ([873](https://github.com/neo4j-labs/neodash/pull/873)).
- Added option to define style config using environment variables for the Docker image ([876](https://github.com/neo4j-labs/neodash/pull/876)).