### PR TITLE
[Feature #884] Helm chart for Kubernetes deployments

### DIFF
--- a/docs/modules/ROOT/pages/developer-guide/build-and-run.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/build-and-run.adoc
@@ -76,7 +76,9 @@ docker run -it –rm -p 5005:5005 neodash
 
 == Run on Kubernetes
 
-An example of a pod definition YAML file to create a NeoDash pod in a cluster:
+=== To deploy using YAML files
+
+YAML examples are available in the https://github.com/neo4j-labs/neodash[the NeoDash repository]. Here is an example of a pod definition YAML file to create a NeoDash pod in a cluster:
 
 ....
 apiVersion: v1
@@ -107,4 +109,119 @@ spec:
       targetPort: 5005
     selector:
       project: neodash
+....
+
+=== To deploy using a Helm Charts
+
+A Kubernetes Helm chart is available in the https://github.com/neo4j-labs/neodash[the NeoDash repository] and here is the full example of the Helm chart values.yaml file,
+
+....
+# Name override or full name override
+nameOverride: ''
+fullnameOverride: neodash-test
+
+# Number of pods
+replicaCount: 1
+
+# Image Details
+image:
+  repository: neo4jlabs/neodash
+  pullPolicy: IfNotPresent
+  tag: 'latest'
+imagePullSecrets: [] # Image pull secret if any
+
+# Pod annotations, labels and security context
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+
+# Mode configuration using environment variables
+# Set reader mode environment variables when enable_reader_mode is true
+enable_reader_mode: true
+env: 
+  - name: "ssoEnabled"
+    value: "false"
+  - name: "standalone"
+    value: "true"
+  - name: "standaloneProtocol"
+    value: "neo4j+s"
+  - name: "standaloneHost"
+    value: "localhost"
+  - name: "standalonePort"
+    value: "7687"
+  - name: "standaloneDatabase"
+    value: neo4j
+  - name: "standaloneDashboardName"
+    value: "test"
+  - name: "standaloneDashboardDatabase"
+    value: neo4j
+  - name: "standaloneAllowLoad"
+    value: "false"
+  - name: "standaloneLoadFromOtherDatabases"
+    value: "false"
+  - name: "standaloneMultiDatabase"
+    value: "false"
+
+# Environment variable from secret
+envFromSecrets: []
+  # standaloneUsername: 
+      # secretName: "neo4j-connection-secrets"
+      # key: "username"
+  # standalonePassword: 
+      # secretName: "neo4j-connection-secrets"
+      # key: "password"
+
+# Service details
+service:
+  type: LoadBalancer # Can also be ClusterIP or NodePort  
+  port: 5005 # For the service to listen in for Traffic
+  targetPort: 5005 # Target port is the container port
+  annotations: {} # Service annotations for the LoadBalance
+
+# Ingress
+ingress:
+  enabled: false # Enable Kubernetes Ingress
+  className: 'alb' # Class Name
+  annotations: {} # Cloud LoadBalancer annotations
+  hosts: []
+    # - host: neodash.example.com
+    #   paths:
+    #     - path: '/'
+    #       pathType: Prefix
+  tls: []
+
+# Pod resources request, limits and health check
+resources: 
+  requests:
+    memory: "64Mi"
+    cpu: "250m"
+  limits:
+    memory: "128Mi"
+    cpu: "500m"
+livenessProbe:
+  httpGet:
+    path: /*
+    port: 5005
+readinessProbe:
+  httpGet:
+    path: /*
+    port: 5005
+
+# Pod Autoscaler
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 100
+  # targetCPUUtilizationPercentage: 80
+
+# Pod Volumes
+volumes: []
+volumeMounts: []
+
+# Service Account
+serviceAccount:
+  create: true
+  automount: true
+  # annotations: {}
+  # name: ''
 ....

--- a/docs/modules/ROOT/pages/developer-guide/build-and-run.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/build-and-run.adoc
@@ -78,7 +78,7 @@ docker run -it –rm -p 5005:5005 neodash
 
 === To deploy using YAML files
 
-YAML examples are available in the https://github.com/neo4j-labs/neodash[the NeoDash repository]. Here is an example of a pod definition YAML file to create a NeoDash pod in a cluster:
+YAML examples are available in the https://github.com/neo4j-labs/neodash[NeoDash repository]. Here is an example of a pod definition YAML file to create a NeoDash pod in a cluster:
 
 ....
 apiVersion: v1

--- a/k8s-deploy/neodash/.helmignore
+++ b/k8s-deploy/neodash/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s-deploy/neodash/Chart.yaml
+++ b/k8s-deploy/neodash/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: neodash
+description: A NeoDash Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.4.8"

--- a/k8s-deploy/neodash/README.md
+++ b/k8s-deploy/neodash/README.md
@@ -1,0 +1,76 @@
+# NeoDash
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+A NeoDash Helm chart for Kubernetes
+
+## Resources
+
+Following are the Kubernetes resources utilized for the NeoDash.
+
+- Deployment
+- Service
+- Ingress
+- Service Account
+- Horizontal Pod Autoscalar (HPA)
+
+## Values Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaling.enabled | bool | `false` | Enable/disable Autoscaling |
+| enable_reader_mode | bool | `true` | Enable/disable Reader mode |
+| envFromSecrets | list | `[]` | Environment variables from secrets |
+| fullnameOverride | string | `"neodash-test"` | Name override applies to all resources |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"neo4jlabs/neodash"` |  Image repository and Image name |
+| image.tag | string | `"latest"` | Image version |
+| imagePullSecrets | list | `[]` | Image pull secrets if any |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Additional labels |
+| podSecurityContext | object | `{}` | Security Context if any |
+| ingress.annotations | object | `{}` | Ingress Annotations for load balancers |
+| ingress.className | string | `"alb"` | Ingress Class |
+| ingress.enabled | bool | `false` | Enable/disable Ingress |
+| ingress.hosts | list | `[]` | Host Details |
+| ingress.tls | list | `[]` | TLS details |
+| livenessProbe.httpGet.path | string | `"/*"` | LivenessProbe path |
+| livenessProbe.httpGet.port | int | `5005` | LivenessProbe port |
+| readinessProbe.httpGet.path | string | `"/*"` | Readiness path |
+| readinessProbe.httpGet.port | int | `5005` | Readiness port |
+| replicaCount | int | `1` | Replica count |
+| resources.limits.cpu | string | `"500m"` | CPU limit |
+| resources.limits.memory | string | `"128Mi"` | Memory limit |
+| resources.requests.cpu | string | `"250m"` | CPU request |
+| resources.requests.memory | string | `"64Mi"` | Memory request |
+| service.annotations | object | `{}` | Service annotations |
+| service.port | int | `5005` | Service port |
+| service.targetPort | int | `5005` | Service target port |
+| service.type | string | `"LoadBalancer"` | Type of service, other options are `ClusterIP` or `NodePort`  |
+| serviceAccount.automount | bool | `true` | Enable/disable service account auto mount to pod |
+| serviceAccount.create | bool | `true` | Enable/disable service account |
+| volumeMounts | list | `[]` | Volume mounts on pod |
+| volumes | list | `[]` | Volumes for pod |
+| env | list |<br><pre lang="YAML">- name: "ssoEnabled" &#13;  value: "false" &#13;- name: "standalone" &#13;  value: "true" &#13;- name: "standaloneProtocol" &#13;  value: "neo4j+s" &#13;- name: "standaloneHost" &#13;  value: "localhost" &#13;- name: "standalonePort" &#13;  value: "7687" &#13;- name: "standaloneDatabase" &#13;  value: "neo4j" &#13;- name: "standaloneDashboardName" &#13;  value: "test" &#13;- name: "standaloneDashboardDatabase" &#13;  value: "neo4j" &#13;- name: "standaloneAllowLoad" &#13;  value: "false" &#13;- name: "standaloneLoadFromOtherDatabases" &#13;  value: "false" &#13;- name: "standaloneMultiDatabase" &#13;  value: "false" &#13;</pre> | Env variables for reader mode |
+
+## Usage
+
+- To install this helm chart run the following command,
+
+    ```bash
+    helm install ./neodash <release-name> -n <namespace-name>
+    ```
+
+- To upgrade the release run the following command,
+
+    ```bash
+    helm upgrade ./neodash <release-name> -n <namespace-name>
+    ```
+
+- To uninstall the release run the following command,
+
+    ```bash
+    helm uninstall <release-name> -n <namespace-name>
+    ```
+
+> **Note:** To use custom values files, pass `-f <path-to-values-file>.yaml` for the above command.

--- a/k8s-deploy/neodash/templates/NOTES.txt
+++ b/k8s-deploy/neodash/templates/NOTES.txt
@@ -1,0 +1,26 @@
+The NeoDash application has been successfully deployed, here is the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "neodash.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "neodash.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "neodash.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "neodash.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+Note: Give it a couple of minutes for the ingress to acquire a certificate and setup the DNS records for hostname specified.
+
+If the above url is not working, please run the kubectl describe ingress -n {{ .Release.Namespace }} command and check the events for any errors.

--- a/k8s-deploy/neodash/templates/NOTES.txt
+++ b/k8s-deploy/neodash/templates/NOTES.txt
@@ -20,7 +20,3 @@ The NeoDash application has been successfully deployed, here is the application 
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
-
-Note: Give it a couple of minutes for the ingress to acquire a certificate and setup the DNS records for hostname specified.
-
-If the above url is not working, please run the kubectl describe ingress -n {{ .Release.Namespace }} command and check the events for any errors.

--- a/k8s-deploy/neodash/templates/_helpers.tpl
+++ b/k8s-deploy/neodash/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "neodash.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "neodash.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "neodash.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "neodash.labels" -}}
+helm.sh/chart: {{ include "neodash.chart" . }}
+{{ include "neodash.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "neodash.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "neodash.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "neodash.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "neodash.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s-deploy/neodash/templates/deployment.yaml
+++ b/k8s-deploy/neodash/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "neodash.fullname" . }}
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "neodash.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "neodash.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "neodash.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- if ne 5005 (int .Values.service.targetPort) }}
+            - name: NGINX_PORT
+              value: {{ .Values.service.port | quote }}
+            {{- end }}
+            {{- if .Values.enable_reader_mode}}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.envFromSecrets }}
+            {{- range $key, $value := .Values.envFromSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $value.secretName }}
+                  key: {{ $value.key }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s-deploy/neodash/templates/deployment.yaml
+++ b/k8s-deploy/neodash/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "neodash.serviceAccountName" . }}
+      automountServiceAccountToken: false
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/k8s-deploy/neodash/templates/hpa.yaml
+++ b/k8s-deploy/neodash/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "neodash.fullname" . }}
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "neodash.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/k8s-deploy/neodash/templates/ingress.yaml
+++ b/k8s-deploy/neodash/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "neodash.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s-deploy/neodash/templates/service.yaml
+++ b/k8s-deploy/neodash/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "neodash.fullname" . }}
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "neodash.selectorLabels" . | nindent 4 }}

--- a/k8s-deploy/neodash/templates/serviceaccount.yaml
+++ b/k8s-deploy/neodash/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "neodash.serviceAccountName" . }}
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/k8s-deploy/neodash/templates/tests/test-connection.yaml
+++ b/k8s-deploy/neodash/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "neodash.fullname" . }}-test-connection"
+  labels:
+    {{- include "neodash.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "neodash.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/k8s-deploy/neodash/templates/tests/test-connection.yaml
+++ b/k8s-deploy/neodash/templates/tests/test-connection.yaml
@@ -7,9 +7,12 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  automountServiceAccountToken: false
   containers:
     - name: wget
       image: busybox
       command: ['wget']
       args: ['{{ include "neodash.fullname" . }}:{{ .Values.service.port }}']
+      resources:
+        {{- toYaml .Values.resources | nindent 8 }}
   restartPolicy: Never

--- a/k8s-deploy/neodash/values.yaml
+++ b/k8s-deploy/neodash/values.yaml
@@ -1,0 +1,108 @@
+# Name override or full name override
+nameOverride: ''
+fullnameOverride: neodash-test
+
+# Number of pods
+replicaCount: 1
+
+# Image Details
+image:
+  repository: neo4jlabs/neodash
+  pullPolicy: IfNotPresent
+  tag: 'latest'
+imagePullSecrets: [] # Image pull secret if any
+
+# Pod annotations, labels and security context
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+
+# Mode configuration using environment variables
+# Set reader mode environment variables when enable_reader_mode is true
+enable_reader_mode: true
+env: 
+  - name: "ssoEnabled"
+    value: "false"
+  - name: "standalone"
+    value: "true"
+  - name: "standaloneProtocol"
+    value: "neo4j+s"
+  - name: "standaloneHost"
+    value: "localhost"
+  - name: "standalonePort"
+    value: "7687"
+  - name: "standaloneDatabase"
+    value: neo4j
+  - name: "standaloneDashboardName"
+    value: "test"
+  - name: "standaloneDashboardDatabase"
+    value: neo4j
+  - name: "standaloneAllowLoad"
+    value: "false"
+  - name: "standaloneLoadFromOtherDatabases"
+    value: "false"
+  - name: "standaloneMultiDatabase"
+    value: "false"
+
+# Environment variable from secret
+envFromSecrets: []
+  # standaloneUsername: 
+      # secretName: "neo4j-connection-secrets"
+      # key: "username"
+  # standalonePassword: 
+      # secretName: "neo4j-connection-secrets"
+      # key: "password"
+
+# Service details
+service:
+  type: LoadBalancer # Can also be ClusterIP or NodePort  
+  port: 5005 # For the service to listen in for Traffic
+  targetPort: 5005 # Target port is the container port
+  annotations: {} # Service annotations for the LoadBalance
+
+# Ingress
+ingress:
+  enabled: false # Enable Kubernetes Ingress
+  className: 'alb' # Class Name
+  annotations: {} # Cloud LoadBalancer annotations
+  hosts: []
+    # - host: neodash.example.com
+    #   paths:
+    #     - path: '/'
+    #       pathType: Prefix
+  tls: []
+
+# Pod resources request, limits and health check
+resources: 
+  requests:
+    memory: "64Mi"
+    cpu: "250m"
+  limits:
+    memory: "128Mi"
+    cpu: "500m"
+livenessProbe:
+  httpGet:
+    path: /*
+    port: 5005
+readinessProbe:
+  httpGet:
+    path: /*
+    port: 5005
+
+# Pod Autoscaler
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 100
+  # targetCPUUtilizationPercentage: 80
+
+# Pod Volumes
+volumes: []
+volumeMounts: []
+
+# Service Account
+serviceAccount:
+  create: true
+  automount: true
+  # annotations: {}
+  # name: ''

--- a/k8s-deploy/sample-k8s-yamls/deployment.yaml
+++ b/k8s-deploy/sample-k8s-yamls/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: neodash-deploy
     spec:
       serviceAccountName: neodash-test
+      automountServiceAccountToken: false
       containers:
         - name: neodash
           image: "neo4jlabs/neodash:latest"

--- a/k8s-deploy/sample-k8s-yamls/deployment.yaml
+++ b/k8s-deploy/sample-k8s-yamls/deployment.yaml
@@ -1,0 +1,65 @@
+---
+# Source: neodash/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neodash
+  labels:
+    application: neodash-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: neodash-deploy
+  template:
+    metadata:
+      labels:
+        application: neodash-deploy
+    spec:
+      serviceAccountName: neodash-test
+      containers:
+        - name: neodash
+          image: "neo4jlabs/neodash:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 5005
+              protocol: TCP
+          env:
+            - name: ssoEnabled
+              value: "false"
+            - name: standalone
+              value: "true"
+            - name: standaloneProtocol
+              value: neo4j+s
+            - name: standaloneHost
+              value: localhost
+            - name: standalonePort
+              value: "7687"
+            - name: standaloneDatabase
+              value: neo4j
+            - name: standaloneDashboardName
+              value: test
+            - name: standaloneDashboardDatabase
+              value: neo4j
+            - name: standaloneAllowLoad
+              value: "false"
+            - name: standaloneLoadFromOtherDatabases
+              value: "false"
+            - name: standaloneMultiDatabase
+              value: "false"
+          livenessProbe:
+            httpGet:
+              path: /*
+              port: 5005
+          readinessProbe:
+            httpGet:
+              path: /*
+              port: 5005
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 250m
+              memory: 64Mi

--- a/k8s-deploy/sample-k8s-yamls/service.yaml
+++ b/k8s-deploy/sample-k8s-yamls/service.yaml
@@ -1,0 +1,17 @@
+---
+# Source: neodash/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: neodash
+  labels:
+    application: neodash-deploy
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5005
+      targetPort: 5005
+      protocol: TCP
+      name: http
+  selector:
+    application: neodash-deploy


### PR DESCRIPTION
## PR Description
This is a new feature request to create a Helm chart to support the Kubernetes based deployments in a package pattern. This Helm chart should enable the NeoDash deployment in either editor or reader mode for easy versioning, packaging and installing these dashboards at an enterprise level.

The solution includes a Helm chart with the following Kubernetes resources templates to support the editor or reader mode for ease of deployment,

- Deployment
- Service
- Service Account
- Ingress (Optional)
- Values file (Default configurations)
- Along with the Helm chart, add the appropriate documentation about the usage and default values.

As an alternative solution I also included the required Kubernetes YAML files to deploy the NeoDash with Kubectl commands.
#884