### PR TITLE
changes to add ssl support

### DIFF
--- a/ssl/Dockerfile
+++ b/ssl/Dockerfile
@@ -1,0 +1,25 @@
+# build stage
+FROM neo4jlabs/neodash:latest AS neodash
+
+ENV NGINX_HTTPS_PORT=5443
+
+USER root
+
+RUN mkdir -p /etc/nginx/certs
+
+RUN --mount=type=secret,id=NEODASH_SSL_KEY \
+    base64 -d /run/secrets/NEODASH_SSL_KEY > /etc/nginx/certs/key.pem
+
+RUN --mount=type=secret,id=NEODASH_SSL_CERT \
+    base64 -d /run/secrets/NEODASH_SSL_CERT > /etc/nginx/certs/cert.pem
+
+COPY default.conf /etc/nginx/templates/default.conf.template
+COPY default.conf /etc/nginx/conf.d/
+
+RUN chown -R nginx:nginx /etc/nginx
+
+USER nginx
+EXPOSE $NGINX_HTTPS_PORT
+
+HEALTHCHECK CMD curl --fail "https://localhost:$NGINX_HTTPS_PORT" || exit 1
+LABEL version="1.0"

--- a/ssl/default.conf
+++ b/ssl/default.conf
@@ -1,0 +1,34 @@
+server {
+    listen       ${NGINX_PORT};
+    server_name  localhost;
+    include      mime.types;
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+        index  index.html index.htm;
+    }
+    # redirect server error pages to the static page /50x.html
+    # Note: This is optional, depending on the implementation in React
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+server {
+    listen 5443 ssl;
+    ssl_certificate /etc/nginx/certs/cert.pem;
+    ssl_certificate_key /etc/nginx/certs/key.pem;
+    server_name localhost;
+    include      mime.types;
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+        index  index.html index.htm;
+    }
+    # redirect server error pages to the static page /50x.html
+    # Note: This is optional, depending on the implementation in React
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Adding the docker file and the corresponding conf file to support starting the NeoDash server on https. In our project, we have successfully used this approach to have our NeoDash server run on https port. The idea is to share this solution in the first pass as part of this PR and welcome thoughts for how it looks and if it can go further to be included in the main Docker image for NeoDash.