### PR TITLE
bugfix/ArrayTableWrap

### DIFF
--- a/src/report/ReportRecordProcessing.tsx
+++ b/src/report/ReportRecordProcessing.tsx
@@ -269,16 +269,17 @@ function RenderArray(value, transposedTable = false) {
     mapped = value.map((v, i) => {
       return RenderSubValue(v) + (i < value.length - 1 ? ', ' : '');
     });
-  }
-  // Render Node and Relationship objects, which will look like a Path
-  mapped = value.map((v, i) => {
-    return (
-      <span key={String(`k${i}`) + v}>
-        {RenderSubValue(v)}
-        {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
-      </span>
-    );
-  });
+  } else {
+    // Render Node and Relationship objects, which will look like a Path
+    mapped = value.map((v, i) => {
+      return (
+        <span key={String(`k${i}`) + v}>
+          {RenderSubValue(v)}
+          {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
+        </span>
+      );
+    });
+  };
   return mapped;
 }
 


### PR DESCRIPTION
Fixes issue with wrapping arrays in table charts.

BEFORE:
<img width="1308" alt="Screenshot 2024-08-07 at 15 51 24" src="https://github.com/user-attachments/assets/ce066c74-92ca-4223-bba0-ee5a69350393">

AFTER:
<img width="1308" alt="Screenshot 2024-08-07 at 15 52 45" src="https://github.com/user-attachments/assets/68bf6935-e933-4e7c-aec8-248c0b7a2cca">
