### PR TITLE
rule based styling cell colouring feature

### DIFF
--- a/src/chart/table/TableChart.tsx
+++ b/src/chart/table/TableChart.tsx
@@ -3,6 +3,7 @@ import { DataGrid, GridColumnVisibilityModel } from '@mui/x-data-grid';
 import { ChartProps } from '../Chart';
 import {
   evaluateRulesOnDict,
+  evaluateSingleRuleOnDict,
   generateClassDefinitionsBasedOnRules,
   useStyleRules,
 } from '../../extensions/styling/StyleRuleEvaluator';
@@ -253,7 +254,15 @@ export const NeoTableChart = (props: ChartProps) => {
     getCellClassName: (params) => {
       return ['cell color', 'cell text color']
         .map((e) => {
-          return `rule${evaluateRulesOnDict({ [params.field]: params.value }, styleRules, [e])}`;
+          for (const [index, rule] of styleRules.entries()) {
+            if (rule.targetField) {
+              if (rule.targetField === params.field) {
+                return `rule${evaluateSingleRuleOnDict({ [rule.field]: params.row[rule.field] }, rule, index, [e])}`;
+              }
+            } else {
+              return `rule${evaluateSingleRuleOnDict({ [params.field]: params.value }, rule, index, [e])}`;
+            }
+          }
         })
         .join(' ');
     },

--- a/src/extensions/styling/StyleRuleCreationModal.tsx
+++ b/src/extensions/styling/StyleRuleCreationModal.tsx
@@ -338,6 +338,35 @@ export const NeoCustomReportStyleModal = ({
                                 }}
                                 fluid
                               />
+                              <Autocomplete
+                                className='n-align-middle n-inline-block n-w-5/12 n-pr-1'
+                                disableClearable={true}
+                                id={`autocomplete-label-type${index}`}
+                                size='small'
+                                noOptionsText='*Specify an exact field name'
+                                options={createFieldVariableSuggestions().filter((e) =>
+                                  e.toLowerCase().includes(rule.targetField)
+                                )}
+                                value={rule.targetField ? rule.targetField : (rule.field ? rule.field : '')}
+                                inputValue={rule.targetField ? rule.targetField : (rule.field ? rule.field : '')}
+                                popupIcon={<></>}
+                                style={{ minWidth: 125, visibility: rule.customization.includes("cell") ? 'visible' : 'hidden', display: rule.customization.includes("cell") ? '' : 'none' }}
+                                onInputChange={(event, value) => {
+                                  updateRuleField(index, 'targetField', value);
+                                }}
+                                onChange={(event, newValue) => {
+                                  updateRuleField(index, 'targetField', newValue);
+                                }}
+                                renderInput={(params) => (
+                                  <TextField
+                                    {...params}
+                                    placeholder='Target field name...'
+                                    InputLabelProps={{ shrink: true }}
+                                    style={{ padding: '6px 0 7px' }}
+                                    size={'small'}
+                                  />
+                                )}
+                              />
                               <TextInput
                                 className='n-align-middle n-inline-block n-w-1/12 n-pr-1'
                                 style={{ minWidth: 30 }}

--- a/src/extensions/styling/StyleRuleEvaluator.ts
+++ b/src/extensions/styling/StyleRuleEvaluator.ts
@@ -63,20 +63,24 @@ export const evaluateRulesOnDict = (dict, rules, customizations) => {
   }
   for (const [index, rule] of rules.entries()) {
     // Only check customizations that are specified
-    if (customizations.includes(rule.customization)) {
-      // if the row contains the specified field...
-      if (dict[rule.field] !== undefined && dict[rule.field] !== null) {
-        const realValue = dict[rule.field].low ? dict[rule.field].low : dict[rule.field];
-        const ruleValue = rule.value;
-        if (evaluateCondition(realValue, rule.condition, ruleValue)) {
-          return index;
-        }
-      }
-    }
+    return evaluateSingleRuleOnDict(dict, rule, index, customizations);
   }
   // If no rules are met, return not found (index=-1)
   return -1;
 };
+
+export const evaluateSingleRuleOnDict = (dict, rule, ruleIndex, customizations) => {
+  if (customizations.includes(rule.customization)) {
+    // if the row contains the specified field...
+    if (dict[rule.field] !== undefined && dict[rule.field] !== null) {
+      const realValue = dict[rule.field].low ? dict[rule.field].low : dict[rule.field];
+      const ruleValue = rule.value;
+      if (evaluateCondition(realValue, rule.condition, ruleValue)) {
+        return ruleIndex;
+      }
+    }
+  }
+}
 
 /**
  *  Evaluates the specified rule set on a node object returned by the Neo4j driver.


### PR DESCRIPTION
Allows different cell background/text colour to be changed based on criteria from a different cell entry.

When adding a new styling rule for column X, if "Cell [Background,Text] Colour" is selected, a new field will be available to populate (default is column X) allowing you to style column Y.

<img width="1345" alt="Screenshot 2024-08-08 at 09 39 01" src="https://github.com/user-attachments/assets/93cc2cf7-a3f2-40a1-8afc-62b19b81523e">

<img width="1343" alt="Screenshot 2024-08-08 at 09 40 52" src="https://github.com/user-attachments/assets/fbdf12f9-6fe7-4ae4-80b5-148f0e067c1a">

<img width="1680" alt="Screenshot 2024-08-08 at 09 41 23" src="https://github.com/user-attachments/assets/523e6ece-c5a7-426c-afde-79a1ccc9e2dc">