### PR TITLE
Bugfix/array table wrap

### DIFF
--- a/src/report/ReportRecordProcessing.tsx
+++ b/src/report/ReportRecordProcessing.tsx
@@ -269,16 +269,17 @@ function RenderArray(value, transposedTable = false) {
     mapped = value.map((v, i) => {
       return RenderSubValue(v) + (i < value.length - 1 ? ', ' : '');
     });
-  }
-  // Render Node and Relationship objects, which will look like a Path
-  mapped = value.map((v, i) => {
-    return (
-      <span key={String(`k${i}`) + v}>
-        {RenderSubValue(v)}
-        {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
-      </span>
-    );
-  });
+  } else {
+    // Render Node and Relationship objects, which will look like a Path
+    mapped = value.map((v, i) => {
+      return (
+        <span key={String(`k${i}`) + v}>
+          {RenderSubValue(v)}
+          {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
+        </span>
+      );
+    });
+  };
   return mapped;
 }
 

--- a/src/report/ReportRecordProcessing.tsx
+++ b/src/report/ReportRecordProcessing.tsx
@@ -279,7 +279,7 @@ function RenderArray(value, transposedTable = false) {
         </span>
       );
     });
-  };
+  }
   return mapped;
 }
 


### PR DESCRIPTION
Fixes table wrapping bug where arrays would not be converted to strings prior to displaying.

BEFORE:

<img width="1715" alt="image" src="https://github.com/user-attachments/assets/0c857994-c5e3-4a84-82b6-414fe31ecef8">

AFTER:

<img width="1715" alt="image" src="https://github.com/user-attachments/assets/17feaa0b-d666-42b8-be25-e8058d22b3a5">