### PR TITLE
Improve method for checking "low" property existence in downloadCSV f…

### DIFF
--- a/src/chart/ChartUtils.ts
+++ b/src/chart/ChartUtils.ts
@@ -164,7 +164,7 @@ export const downloadCSV = (rows) => {
     headers.forEach((header) => {
       // Parse value
       let value = row[header];
-      if (value && value.low) {
+      if (value && 'low' in value) {
         value = value.low;
       }
       csv += `${JSON.stringify(value)}`;


### PR DESCRIPTION
This short fix has the objective of parsing number while exporting a CSV, even if the number value is 0.

Check issue #950  for more information.