### PR TITLE
Change to neo4j+s as default protocol

### DIFF
--- a/docs/modules/ROOT/pages/developer-guide/configuration.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/configuration.adoc
@@ -19,7 +19,7 @@ will look like this:
     "ssoProviders": [],
     "ssoDiscoveryUrl": "https://example.com",
     "standalone": false,
-    "standaloneProtocol": "neo4j",
+    "standaloneProtocol": "neo4j+s",
     "standaloneHost": "localhost",
     "standalonePort": "7687",
     "standaloneDatabase": "neo4j",
@@ -55,7 +55,7 @@ mode (false), or reader mode (true). The terms ``Reader mode'' and
 ``Standalone mode'' are used interchangibly.
 
 |standaloneProtocol |string |neo4j |When running in standalone mode, the
-protocol to used for the Neo4j driver. This shoudl be set to one of
+protocol to used for the Neo4j driver. This should be set to one of
 `neo4j`, `neo4j+s`, `neo4j+ssc`, `bolt`, `bolt+s`, or `bolt+ssc`.
 
 |standaloneHost |string |localhost |When running in standalone mode, the

--- a/docs/modules/ROOT/pages/developer-guide/standalone-mode.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/standalone-mode.adoc
@@ -42,7 +42,7 @@ docker run  -it --rm -p 5005:5005 \
     -e ssoProviders=[] \
     -e ssoDiscoveryUrl="https://example.com" \
     -e standalone=true \
-    -e standaloneProtocol="neo4j" \
+    -e standaloneProtocol="neo4j+s" \
     -e standaloneHost="localhost" \
     -e standalonePort="7687" \
     -e standaloneDatabase="neo4j" \

--- a/docs/modules/ROOT/pages/developer-guide/state-management.adoc
+++ b/docs/modules/ROOT/pages/developer-guide/state-management.adoc
@@ -129,7 +129,7 @@ standalone mode.
     "ssoEnabled": false,
     "ssoProviders": [],
     "ssoDiscoveryUrl": "https://example.com",
-    "standaloneProtocol": "neo4j",
+    "standaloneProtocol": "neo4j+s",
     "standaloneHost": "localhost",
     "standalonePort": "7687",
     "standaloneDatabase": "neo4j",

--- a/public/config.json
+++ b/public/config.json
@@ -3,7 +3,7 @@
   "ssoProviders": [],
   "ssoDiscoveryUrl": "https://example.com",
   "standalone": false,
-  "standaloneProtocol": "neo4j",
+  "standaloneProtocol": "neo4j+s",
   "standaloneHost": "localhost",
   "standalonePort": "7687",
   "standaloneDatabase": "neo4j",

--- a/src/application/ApplicationReducer.ts
+++ b/src/application/ApplicationReducer.ts
@@ -58,7 +58,7 @@ const initialState = {
   draft: false,
   aboutModalOpen: false,
   connection: {
-    protocol: 'neo4j',
+    protocol: 'neo4j+s',
     url: DEFAULT_NEO4J_URL,
     port: '7687',
     database: '',

--- a/src/application/ApplicationThunks.ts
+++ b/src/application/ApplicationThunks.ts
@@ -410,7 +410,7 @@ export const loadApplicationConfigThunk = () => async (dispatch: any, getState: 
     ssoProviders: [],
     ssoDiscoveryUrl: 'http://example.com',
     standalone: false,
-    standaloneProtocol: 'neo4j',
+    standaloneProtocol: 'neo4j+s',
     standaloneHost: 'localhost',
     standalonePort: '7687',
     standaloneDatabase: 'neo4j',


### PR DESCRIPTION
As the title says, this feature is about changing the the default protocol from neo4j to neo4j+s in the login page.