### PR TITLE
Fix/715 expand loses node text #715

### DIFF
--- a/src/card/CardThunks.ts
+++ b/src/card/CardThunks.ts
@@ -76,7 +76,7 @@ export const updateReportTypeThunk = (id, type) => (dispatch: any, getState: any
 };
 
 export const updateFieldsThunk =
-  (id, fields, schema = false) =>
+  (id, fields, schema = false, additive = false) =>
   (dispatch: any, getState: any) => {
     try {
       const state = getState();
@@ -118,7 +118,9 @@ export const updateFieldsThunk =
               }
             } else if (selectableFields[selection].type == SELECTION_TYPES.NODE_PROPERTIES) {
               // For node property selections, select the most obvious properties of the node to display.
-              const selection = getSelectionBasedOnFields(fields, oldSelection, autoAssignSelectedProperties);
+              // Add in oldSelection and additive boolean to determine if we default to oldSelection first to reuse previously
+              // set selections
+              const selection = getSelectionBasedOnFields(fields, oldSelection, autoAssignSelectedProperties, additive);
               dispatch(updateAllSelections(pagenumber, id, selection));
             } else {
               // Else, default the selection to the Nth item of the result set fields.

--- a/src/chart/ChartUtils.ts
+++ b/src/chart/ChartUtils.ts
@@ -433,8 +433,16 @@ export function castToNeo4jDate(value: object) {
 /**
  * Creates a default selection config for a node-property based chart footer.
  */
-export function getSelectionBasedOnFields(fields, oldSelection = {}, autoAssignSelectedProperties = true) {
-  const selection = {};
+export function getSelectionBasedOnFields(
+  fields,
+  oldSelection = {},
+  autoAssignSelectedProperties = true,
+  additive: boolean
+) {
+  // if additive, keep the old selection
+  const selection = additive ? structuredClone(oldSelection) : {};
+
+  // if new field not found in old selection, use a default
   fields.forEach((nodeLabelAndProperties) => {
     const label = nodeLabelAndProperties[0];
     const properties = nodeLabelAndProperties.slice(1);

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -69,9 +69,9 @@ export const NeoReport = ({
   }
   const debouncedRunCypherQuery = useCallback(debounce(runCypherQuery, RUN_QUERY_DELAY_MS), []);
 
-  const setSchema = (id, schema) => {
+  const setSchema = (id, schema, additive = false) => {
     if (type === 'graph' || type === 'map' || type === 'gantt' || type === 'graph3d') {
-      setSchemaDispatch(id, schema);
+      setSchemaDispatch(id, schema, additive); // schema=true
     }
   };
   const populateReport = (debounced = true) => {
@@ -221,7 +221,7 @@ export const NeoReport = ({
         HARD_ROW_LIMITING,
         queryTimeLimit,
         (schema) => {
-          setSchema(id, schema);
+          setSchema(id, schema, true);
         }
       );
     },
@@ -357,8 +357,8 @@ const mapDispatchToProps = (dispatch) => ({
   getCustomDispatcher: () => {
     return dispatch;
   },
-  setSchemaDispatch: (id: any, schema: any) => {
-    dispatch(updateFieldsThunk(id, schema, true));
+  setSchemaDispatch: (id: any, schema: any, additive: boolean) => {
+    dispatch(updateFieldsThunk(id, schema, true, additive));
   },
 });
 


### PR DESCRIPTION
#715 
Added a boolean `additive` to control when to default the selections to the old selection first before proceeding with getting the other selections based on fields. 

Maybe I can remove the boolean and have the getSelectionBasedOnFields function to always initially use the oldSelection first? For example, I expand a node on the graph report that reveals new labels > I set selections for new labels > I trigger rerun of the graph report's query from another Card. If those nodes with the new labels I recently set selections for come back, I'd expect those selections to persist. In this case, I should also have to pass in `true` for additive in the setSchema arguments in Report.tsx:populateReport function. Are there any situations where getSelectionBasedOnFields shouldn't default to oldSelection first?