### PR TITLE
Fix idea: concurrency control using last-read-wins global variable (suggestions welcome)

### DIFF
--- a/src/card/CardActions.ts
+++ b/src/card/CardActions.ts
@@ -91,3 +91,9 @@ export const updateReportDatabase = (pagenumber: number, id: number, database: a
   type: UPDATE_REPORT_DATABASE,
   payload: { pagenumber, id, database },
 });
+
+export const UPDATE_LAST_POPULATE_QUERY_TIMESTAMP = 'PAGE/CARD/UPDATE_LAST_POPULATE_QUERY_TIMESTAMP';
+export const updateLastPopulateQueryTimestamp = (pagenumber: number, id: number, timestamp: number) => ({
+  type: UPDATE_LAST_POPULATE_QUERY_TIMESTAMP,
+  payload: { pagenumber, id, lastPopulateQueryTimestamp: timestamp },
+});

--- a/src/card/CardReducer.ts
+++ b/src/card/CardReducer.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_REPORT_TYPE,
   UPDATE_SELECTION,
   UPDATE_REPORT_DATABASE,
+  UPDATE_LAST_POPULATE_QUERY_TIMESTAMP,
 } from './CardActions';
 import { TOGGLE_CARD_SETTINGS } from './CardActions';
 import { createUUID } from '../utils/uuid';
@@ -38,6 +39,7 @@ export const CARD_INITIAL_STATE = {
   selection: {},
   settings: {},
   collapseTimeout: 'auto',
+  lastPopulateQueryTimestamp: -1,
 };
 
 export const cardReducer = (state = CARD_INITIAL_STATE, action: { type: any; payload: any }) => {
@@ -48,6 +50,11 @@ export const cardReducer = (state = CARD_INITIAL_STATE, action: { type: any; pay
   }
 
   switch (type) {
+    case UPDATE_LAST_POPULATE_QUERY_TIMESTAMP: {
+      const { lastPopulateQueryTimestamp } = payload;
+      state = update(state, { lastPopulateQueryTimestamp });
+      return state;
+    }
     case UPDATE_REPORT_TITLE: {
       const { title } = payload;
       state = update(state, { title: title });

--- a/src/card/CardThunks.ts
+++ b/src/card/CardThunks.ts
@@ -182,3 +182,15 @@ export const updateReportSettingThunk = (id, setting, value) => (dispatch: any, 
     dispatch(createNotificationThunk('Error when updating report settings', e));
   }
 };
+
+/** GET thunk semaphore to be able to retrieve last timestamp to prevent displaying stale result */
+export const getLastPopulateQueryTimestampThunk = (id) => (dispatch: any, getState: any) => {
+  try {
+    const state = getState();
+    const { pagenumber } = state.dashboard.settings;
+    const report = state.dashboard.pages[pagenumber].reports.find((o) => o.id === id);
+    return report ? report.lastPopulateQueryTimestamp : -1;
+  } catch (e) {
+    dispatch(createNotificationThunk('error', e));
+  }
+};

--- a/src/report/ReportQueryRunner.ts
+++ b/src/report/ReportQueryRunner.ts
@@ -53,7 +53,9 @@ export async function runCypherQuery(
   setSchema = () => {
     // eslint-disable-next-line no-console
     // console.log(`Query runner attempted to set schema: ${JSON.stringify(schema)}`);
-  }
+  },
+  thisPopulateQueryTimestamp = -1,
+  getLastTimestampDispatch
 ) {
   // If no query specified, we don't do anything.
   if (query.trim() == '') {
@@ -121,7 +123,16 @@ export async function runCypherQuery(
         return;
       }
       setStatus(QueryStatus.COMPLETE);
-      setRecords(records);
+      if (getLastTimestampDispatch && typeof getLastTimestampDispatch === 'function') {
+        const lastTimestamp = getLastTimestampDispatch();
+        // console.log(thisPopulateQueryTimestamp, `Query complete, report.lastQueryTs =`, lastTimestamp);
+        if (thisPopulateQueryTimestamp >= lastTimestamp) {
+          setRecords(records);
+        }
+      } else {
+        setRecords(records);
+      }
+
       // console.log("TODO remove this - QUERY WAS EXECUTED SUCCESFULLY!")
 
       transaction.commit();


### PR DESCRIPTION
For example, the issue is, I have a dashboard with a parameter select card and a Single Value card. I choose parameter X, the single value card updates, but the query takes a while to run. While the query is running, I choose another parameter, triggering the query to run again, but it returns before the first, and updates the single value card. When the first query finally finishes, the single value card gets updated with a now stale value.

 Ideally, any transaction about to run against Neo4j should cancel any currently running transactions that shares the same query, but this wasn't trivial and/or not possible to do at the time. Currently, afaik with the source code, all transactions in reports are allowed to run. And so, I dealt with this at the frontend layer. Specifically, I created a global redux variable `lastPopulateQueryTimestamp` associated with the Card state that tracks/represents the latest call of the query. This is set whenever a query is run. When the transaction returns, the logic checks if its timestamp is the same as the global, and only if so, sets the records. In order to get access to that current store inside a non-react component, I had to implement a GET thunk to read and return it. I wrapped it in a dispatch and passed it down the functions so the post-`await` block is able to access the store.