### PR TITLE
add option for InitContainers into helm chart

### DIFF
--- a/k8s-deploy/neodash/Chart.yaml
+++ b/k8s-deploy/neodash/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s-deploy/neodash/templates/deployment.yaml
+++ b/k8s-deploy/neodash/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "neodash.serviceAccountName" . }}
       automountServiceAccountToken: false
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/k8s-deploy/neodash/values.yaml
+++ b/k8s-deploy/neodash/values.yaml
@@ -12,6 +12,9 @@ image:
   tag: 'latest'
 imagePullSecrets: [] # Image pull secret if any
 
+# Init containers
+initContainers: []
+
 # Pod annotations, labels and security context
 podAnnotations: {}
 podLabels: {}
@@ -20,7 +23,7 @@ podSecurityContext: {}
 # Mode configuration using environment variables
 # Set reader mode environment variables when enable_reader_mode is true
 enable_reader_mode: true
-env: 
+env:
   - name: "ssoEnabled"
     value: "false"
   - name: "standalone"
@@ -46,16 +49,16 @@ env:
 
 # Environment variable from secret
 envFromSecrets: []
-  # standaloneUsername: 
+  # standaloneUsername:
       # secretName: "neo4j-connection-secrets"
       # key: "username"
-  # standalonePassword: 
+  # standalonePassword:
       # secretName: "neo4j-connection-secrets"
       # key: "password"
 
 # Service details
 service:
-  type: LoadBalancer # Can also be ClusterIP or NodePort  
+  type: LoadBalancer # Can also be ClusterIP or NodePort
   port: 5005 # For the service to listen in for Traffic
   targetPort: 5005 # Target port is the container port
   annotations: {} # Service annotations for the LoadBalance
@@ -73,7 +76,7 @@ ingress:
   tls: []
 
 # Pod resources request, limits and health check
-resources: 
+resources:
   requests:
     memory: "64Mi"
     cpu: "250m"


### PR DESCRIPTION
* added an option for add init containers
* together with combination of https://github.com/neo4j-labs/neodash/pull/1069 it will be possible to deploy into k8s clusters that have kyverno policy for read-only file system for pods.

the final values.yaml file would look like this:

```
initContainers:
  - name: init-config
    image: neo4jlabs/neodash:latest
    imagePullPolicy: IfNotPresent
    command:
      - sh
      - -c
      - |
        cp -r /usr/share/nginx/html/* /tmp/nginx-html && \
        cp -r /etc/nginx/templates/* /tmp/nginx-config-templates && \
        cp -r /etc/nginx/conf.d/* /tmp/nginx-conf-d
    volumeMounts:
      - name: nginx-html
        mountPath: /tmp/nginx-html
      - name: nginx-config-templates
        mountPath: /tmp/nginx-config-templates
      - name: nginx-conf-d
        mountPath: /tmp/nginx-conf-d

volumes:
  - name: nginx-html
    emptyDir:
      sizeLimit: 100Mi
  - name: nginx-config-templates
    emptyDir:
      sizeLimit: 10Mi
  - name: nginx-conf-d
    emptyDir:
      sizeLimit: 10Mi
  - name: nginx-cache
    emptyDir:
      medium: Memory
      sizeLimit: 128Mi
  - name: nginx-run
    emptyDir:
      medium: Memory
      sizeLimit: 128Mi
  - name: nginx-tmp
    emptyDir:
      medium: Memory
      sizeLimit: 128Mi

volumeMounts:
  - name: nginx-html
    mountPath: /usr/share/nginx/html
  - name: nginx-config-templates
    mountPath: /etc/nginx/templates
  - name: nginx-conf-d
    mountPath: /etc/nginx/conf.d
  - name: nginx-cache
    mountPath: /var/cache/nginx
  - name: nginx-run
    mountPath: /var/run
  - name: nginx-tmp
    mountPath: /tmp
```

with this config the config files for nginx are writable but at the same the the containers pass the `readOnlyRootFilesystem: true` check

